### PR TITLE
info 페이지 마크업 초안완료 및 코드 정리

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -124,7 +124,7 @@ a {
   @include regular(3.75vw);
   width: calc(100%-32px);
   height: 6.6vw;
-  background-color: $white;
+  background-color: transparent;
   border: none;
   border-bottom: 1px solid $grey;
   margin: 2.5vw 0;
@@ -158,4 +158,12 @@ a {
   flex-direction: column;
   justify-content: flex-start;
   gap: $gap;
+}
+@mixin signin-bg {
+  width: 100vw;
+  height: 100vh;
+  background-color: #222222;
+  background-image: url('~@assets/splashImage.svg');
+  background-repeat: no-repeat;
+  background-position: center bottom;
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,6 +7,7 @@ import Write from '@pages/Write'
 import SignIn from '@pages/SignIn'
 import Posting from '@pages/Posting'
 import Feeds from '@pages/Feeds'
+import Info from '@pages/Info'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
@@ -14,6 +15,7 @@ root.render(
     <Routes>
       <Route path="/Feed" element={<Feed />} />
       <Route path="/Write" element={<Write />} />
+      <Route path="/SignIn/Info" element={<Info />} />
       <Route path="/SignIn" element={<SignIn />} />
       <Route path="/createfeed" element={<CreateFeed />} />
       <Route path="/posting" element={<Posting />} />

--- a/frontend/src/pages/Info/index.tsx
+++ b/frontend/src/pages/Info/index.tsx
@@ -1,0 +1,29 @@
+import React, { useRef } from 'react'
+import './style.scss'
+import XoxoIcon from '@assets/xoxoIcon.svg'
+import { onChange } from '@src/util'
+
+const Info = () => {
+  const userNickname = useRef('')
+  return (
+    <div className="signin-page">
+      <div className="signin-body">
+        <img className="icon-image" src={XoxoIcon} alt="serviceIcon" />
+        <div className="form-wrapper">
+          <label className="form-label" htmlFor="userNickname">
+            닉네임
+          </label>
+          <input
+            type="text"
+            id="userNickname"
+            placeholder="  닉네임을 입력해주세요. ( 조합 10자리 이하)  "
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e, userNickname)}
+          />
+          <button className="form-button">시작하기</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Info

--- a/frontend/src/pages/Info/style.scss
+++ b/frontend/src/pages/Info/style.scss
@@ -1,0 +1,27 @@
+@import '@src/global';
+
+.signin-page {
+  @include signin-bg;
+  @include page;
+}
+.signin-body {
+  @include vcenter;
+  @include body;
+  .icon-image {
+    height: 20vw;
+  }
+}
+.form-wrapper {
+  @include display-col(1.25vw);
+  width: 100%;
+  .form-label {
+    @include medium(4.375vw, $white);
+  }
+  input {
+    @include input-common;
+  }
+  .form-button {
+    @include button-large(#fee500, $black);
+    margin-top: 9vw;
+  }
+}

--- a/frontend/src/pages/SignIn/style.scss
+++ b/frontend/src/pages/SignIn/style.scss
@@ -1,34 +1,29 @@
-@import "@src/global";
+@import '@src/global';
 
-.signin-page{
-    width: 100vw;
-    height: 100vh;
-    background-color: #222222;
-    background-image: url('~@assets/splashImage.svg');
-    background-repeat: no-repeat;
-    background-position: center bottom;
-    .signin-body {
-        @include vcenter;
-        padding: 15vw 16px;
-        flex-direction: column;
-        .icon-image {
-            width: 100%;
-            margin: 56px 0;
-        }
-        .xoxo-info {
-            width: 100%;
-            text-align: right;
-            @include bold(3.75vw, $white);
-            line-height: 2vw;
-        }
-        .kakao-auth-button {
-            @include button-large(#FEE500, $black);
-            @include vcenter;
-            flex-direction: row;
-            span {
-                margin-left: 4px;
-                margin-bottom: 2px;
-            }
-        }
+.signin-page {
+  @include signin-bg;
+  .signin-body {
+    @include vcenter;
+    padding: 15vw 16px;
+    flex-direction: column;
+    .icon-image {
+      width: 100%;
+      margin: 56px 0;
     }
+    .xoxo-info {
+      width: 100%;
+      text-align: right;
+      @include bold(3.75vw, $white);
+      line-height: 2vw;
+    }
+    .kakao-auth-button {
+      @include button-large(#fee500, $black);
+      @include vcenter;
+      flex-direction: row;
+      span {
+        margin-left: 4px;
+        margin-bottom: 2px;
+      }
+    }
+  }
 }

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -1,0 +1,4 @@
+export const onChange = (e: React.ChangeEvent<HTMLInputElement>, type: React.MutableRefObject<string>) => {
+  const value = e.target.value
+  type.current = value
+}


### PR DESCRIPTION
* info 페이지 마크업 초안 완료
* global.scss의 input-common Mixin의 백그라운드를 투명으로 변경
* Info 페이지 테스를 위한 임시 라우팅 추가
* signin page의 배경을 global.scss의 mixin으로 변경
* useRef를 활용한 Input 태그 onChange 함수 생성