### PR TITLE
Feed entity `Maxcount` 컬럼 삭제 및 `isGroupFeed` 컬럼 추가

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -40,5 +40,6 @@ module.exports = {
     'class-methods-use-this': 0,
     'max-classes-per-file': 0,
     'class-methods-use-this': 0,
+    'no-restricted-syntax': 0,
   },
 };

--- a/backend/src/ServerErrorHandlingFilter.ts
+++ b/backend/src/ServerErrorHandlingFilter.ts
@@ -9,7 +9,7 @@ import { Response } from 'express';
 import {
   DuplicateJoinException,
   DuplicateNicknameException,
-  EmptyGroupFeedMemberList,
+  GroupFeedMemberListCountException,
   InternalDBException,
   InvalidFKConstraintException,
   NonExistFeedIdException,
@@ -46,8 +46,8 @@ export class ServerErrorHandlingFilter implements ExceptionFilter {
         exception = new NonExistFeedIdException();
         break;
 
-      case 'MemberListMustMoreThanOne':
-        exception = new EmptyGroupFeedMemberList();
+      case 'GroupFeedMemberListCountException':
+        exception = new GroupFeedMemberListCountException();
         break;
 
       case 'DuplicateKakaoIdError':

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthenticationModule } from './authentication/authentication.module';
 
 import { FeedModule } from './feed/feed.module';
+import { PostingController } from './posting/posting.controller';
+import { PostingService } from './posting/posting.service';
+import { PostingModule } from './posting/posting.module';
 
 import UsersModule from './users/users.module';
 import AppController from './app.controller';
@@ -46,6 +49,8 @@ import configuration from '../configuration';
     AuthenticationModule,
 
     FeedModule,
+
+    PostingModule,
   ],
   controllers: [AppController],
   providers: [AppService, ConfigService],

--- a/backend/src/common/DueDate.guard.ts
+++ b/backend/src/common/DueDate.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  AccessBeforeDueDateException,
+  InvalidPostingId,
+} from 'src/error/httpException';
+import { PostingService } from 'src/posting/posting.service';
+
+@Injectable()
+export class DueDateGuard implements CanActivate {
+  constructor(private readonly postingService: PostingService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    const { postingId } = req.params;
+
+    const posting = await this.postingService.getPosting({ id: postingId });
+    if (!posting) throw new InvalidPostingId();
+
+    if (posting[0].feed.dueDate < new Date()) return true;
+
+    throw new AccessBeforeDueDateException();
+  }
+}

--- a/backend/src/entities/Feed.entity.ts
+++ b/backend/src/entities/Feed.entity.ts
@@ -18,24 +18,25 @@ export class Feed implements FeedInterface {
   id: number;
 
   @IsNotEmpty()
-  @Column({ type: 'varchar', length: 15 })
+  @Column({ type: 'varchar', length: 15, nullable: false })
   name: string;
 
   @IsUrl()
   @IsNotEmpty()
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: false })
   thumbnail: string;
 
   @IsNotEmpty()
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: false })
   description: string;
 
   @IsNotEmpty()
-  @Column({ type: 'datetime' })
+  @Column({ type: 'datetime', nullable: false })
   dueDate: Date;
 
-  @Column('int', { default: 0 })
-  memberCount: number;
+  @IsNotEmpty()
+  @Column('bool', { nullable: false })
+  isGroupFeed: boolean;
 
   @DeleteDateColumn()
   deletedAt: Date | null;

--- a/backend/src/entities/Posting.entity.ts
+++ b/backend/src/entities/Posting.entity.ts
@@ -26,6 +26,7 @@ export default class Posting implements PostingInterface {
 
   @IsNotEmpty()
   @IsUrl()
+  @Column('varchar')
   thumbnail: string;
 
   @DeleteDateColumn()

--- a/backend/src/entities/entityInterfaces/FeedInterface.ts
+++ b/backend/src/entities/entityInterfaces/FeedInterface.ts
@@ -5,5 +5,5 @@ export interface FeedInterface {
 
   dueDate: Date;
 
-  memberCount: number;
+  isGroupFeed: boolean;
 }

--- a/backend/src/error/httpException.ts
+++ b/backend/src/error/httpException.ts
@@ -132,12 +132,12 @@ export class NonExistFeedIdException extends HttpException {
   }
 }
 
-export class EmptyGroupFeedMemberList extends HttpException {
+export class GroupFeedMemberListCountException extends HttpException {
   constructor() {
     super(
       {
-        error: 'EmptyGroupFeedMember',
-        message: `그룹 피드 생성에는 최소한 한 명 이상의 그룹원이 필요합니다.`,
+        error: 'GroupFeedMemberListCountException',
+        message: `그룹 피드 멤버는 2명 이상 100명 이하입니다.`,
       },
       HttpStatus.UNPROCESSABLE_ENTITY,
     );

--- a/backend/src/error/httpException.ts
+++ b/backend/src/error/httpException.ts
@@ -155,3 +155,27 @@ export class InvalidFKConstraintException extends HttpException {
     );
   }
 }
+
+export class AccessBeforeDueDateException extends HttpException {
+  constructor() {
+    super(
+      {
+        error: 'AccessBeforeDueDateException',
+        message: `피드 공개일 이전에는 포스팅에 접근할 수 없습니다.`,
+      },
+      HttpStatus.FORBIDDEN,
+    );
+  }
+}
+
+export class InvalidPostingId extends HttpException {
+  constructor() {
+    super(
+      {
+        error: 'InvalidPostingId',
+        message: `존재하지 않는 포스팅 입니다.`,
+      },
+      HttpStatus.FORBIDDEN,
+    );
+  }
+}

--- a/backend/src/error/serverError.ts
+++ b/backend/src/error/serverError.ts
@@ -12,10 +12,10 @@ export class NonExistUserError extends Error {
   }
 }
 
-export class MemberListMustMoreThanOne extends Error {
+export class GroupFeedMemberListCountException extends Error {
   constructor() {
-    super('그룹 피드 멤버는 무조건 1명 이상이여야 합니다.'); // (1)
-    this.name = 'MemberListMustMoreThanOne';
+    super('그룹 피드 멤버는 2명 이상 100명 이하입니다'); // (1)
+    this.name = 'GroupFeedMemberListCountException';
   }
 }
 

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  UseGuards,
+  Param,
+  Patch,
+  Post,
+  Get,
+} from '@nestjs/common';
+import { DueDateGuard } from 'src/common/dueDate.guard';
 
 import Feed from 'src/custom/customDecorator/feed.decorator';
 import ValidationPipe422 from 'src/validation';

--- a/backend/src/posting/dto/find.posting.dto.ts
+++ b/backend/src/posting/dto/find.posting.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import Posting from 'src/entities/Posting.entity';
+
+export default class FindPostingDto extends PartialType(Posting) {}

--- a/backend/src/posting/posting.controller.spec.ts
+++ b/backend/src/posting/posting.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostingController } from './posting.controller';
+
+describe('PostingController', () => {
+  let controller: PostingController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PostingController],
+    }).compile();
+
+    controller = module.get<PostingController>(PostingController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/posting/posting.controller.ts
+++ b/backend/src/posting/posting.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Param, UseGuards, Get } from '@nestjs/common';
+import { DueDateGuard } from 'src/common/dueDate.guard';
+import { PostingService } from './posting.service';
+
+@Controller('posting')
+export class PostingController {
+  constructor(private readonly postingService: PostingService) {}
+
+  @Get('test/:postingId')
+  @UseGuards(DueDateGuard)
+  testFunction(@Param('postingId') postingId: number) {
+    return postingId;
+  }
+}

--- a/backend/src/posting/posting.module.ts
+++ b/backend/src/posting/posting.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import Posting from 'src/entities/Posting.entity';
+import { PostingController } from './posting.controller';
+import { PostingService } from './posting.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Posting])],
+  controllers: [PostingController],
+  providers: [PostingService],
+  exports: [PostingService],
+})
+export class PostingModule {}

--- a/backend/src/posting/posting.service.spec.ts
+++ b/backend/src/posting/posting.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostingService } from './posting.service';
+
+describe('PostingService', () => {
+  let service: PostingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostingService],
+    }).compile();
+
+    service = module.get<PostingService>(PostingService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/posting/posting.service.ts
+++ b/backend/src/posting/posting.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import Posting from 'src/entities/Posting.entity';
+import { DBError } from 'src/error/serverError';
+import { Repository } from 'typeorm';
+import FindPostingDto from './dto/find.posting.dto';
+
+@Injectable()
+export class PostingService {
+  constructor(
+    @InjectRepository(Posting) private postingRepository: Repository<Posting>,
+  ) {}
+
+  async getPosting(findPostingDto: FindPostingDto & Record<string, unknown>) {
+    try {
+      const posting = await this.postingRepository.find({
+        where: findPostingDto,
+        relations: ['feed'],
+      });
+      return posting;
+    } catch (e) {
+      console.log(e);
+      throw new DBError('DBError: getUser 오류');
+    }
+  }
+}


### PR DESCRIPTION
### 변경사항
- `Feed` entity `Maxcount` 컬럼 삭제
- `Feed` entity `isGroupFeed{type: boolean}` 컬럼 추가
- GroupFeed MemeberList 2 이상 100 이하로 제한


### 설명
기존에 Maxcount를 통하여 그룹/개인 피드 여부를 판별하였다.
(Maxcount=1이면 개인, 아니면 그룹)

이런 방식을 채택했던 이유는 피드의 현재 회원 수를 사용할 것이라고 생각해서였는데,
- 그룹 피드 UI에서 현재 멤버 수를 보여주지 않음
- 그룹 피드 수정 시 기존의 멤버 수를 사용하지 않음
등의 이유로, 그룹/개인 피드 여부를 구분하는 용도로만 쓰이게 되었다.
따라서 number보다 boolean 컬럼을 사용하는 것이 더 직관적이라 생각하여 수정하였다.