### PR TITLE
validationError 422 에러 메세지 포함하도록 수정

### DIFF
--- a/backend/src/common/authorization.spec.ts
+++ b/backend/src/common/authorization.spec.ts
@@ -37,6 +37,7 @@ describe('권한 부여 가드(AuthorizationGuard) 동작 unit test', () => {
               return { userId: 1 };
             },
           };
+        return null;
       })
       .compile();
 

--- a/backend/src/customValidationPipe.ts
+++ b/backend/src/customValidationPipe.ts
@@ -25,7 +25,7 @@ export default class CustomValidationPipe extends ValidationPipe {
           case 'DuplicatKakaoId':
             throw new DuplicateJoinException();
           default:
-            throw new UnprocessableEntityException();
+            throw new UnprocessableEntityException(validationError.constraints);
         }
       });
     };

--- a/backend/src/customValidationPipe.ts
+++ b/backend/src/customValidationPipe.ts
@@ -8,7 +8,7 @@ import {
   NonExistUserIdException,
 } from './error/httpException';
 
-export default class ValidationPipe422 extends ValidationPipe {
+export default class CustomValidationPipe extends ValidationPipe {
   public createExceptionFactory() {
     return (validationErrors: ValidationError[] = []) => {
       validationErrors.forEach((validationError) => {

--- a/backend/src/entities/Feed.entity.ts
+++ b/backend/src/entities/Feed.entity.ts
@@ -1,5 +1,4 @@
 import { IsNotEmpty, IsUrl } from 'class-validator';
-import IsValidFeedName from 'src/custom/customValidators/feedValidate';
 
 import {
   Entity,
@@ -19,7 +18,6 @@ export class Feed implements FeedInterface {
   id: number;
 
   @IsNotEmpty()
-  @IsValidFeedName()
   @Column({ type: 'varchar', length: 15, nullable: false })
   name: string;
 

--- a/backend/src/feed/feed.controller.spec.ts
+++ b/backend/src/feed/feed.controller.spec.ts
@@ -54,6 +54,7 @@ describe('FeedController', () => {
     })
       .useMocker((token) => {
         if (token === UserReq) return mockUser;
+        return null;
       })
       .overrideGuard(AccessAuthGuard)
       .useValue({ canActivate: () => true })
@@ -130,5 +131,21 @@ describe('FeedController', () => {
     await expect(async () => {
       await feedService.createFeed(mockCreateFeedDto, mockUserId);
     }).rejects.toThrowError(new NonExistUserError());
+  });
+
+  describe('editFeed(개인 피드 수정) unit test', () => {
+    it(`/feed 개인 피드 생성(unit) : 유효한 user_id인지 검사`, async () => {
+      const mockCreateFeedDto = {
+        name: '피드 이름',
+        thumbnail: 'naver.com',
+        description: '피드 1 설명',
+        dueDate: new Date(),
+      };
+
+      const mockUserId = 1000;
+      await expect(async () => {
+        await feedService.createFeed(mockCreateFeedDto, mockUserId);
+      }).rejects.toThrowError(new NonExistUserError());
+    });
   });
 });

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -14,6 +14,7 @@ import Feed from 'src/custom/customDecorator/feed.decorator';
 import User from 'src/entities/User.entity';
 import { UserReq } from 'src/users/decorators/users.decorators';
 import CustomValidationPipe from 'src/customValidationPipe';
+import { AuthorizationGuard } from 'src/common/authorization.guard';
 import CreateFeedDto from './dto/create.feed.dto';
 import { FeedService } from './feed.service';
 
@@ -34,6 +35,7 @@ export class FeedController {
     return feedParam;
   }
 
+  @UseGuards(AuthorizationGuard)
   @Patch('/:feedId')
   async editFeed(
     @Param('feedId') encryptedFeedId: string,
@@ -55,14 +57,15 @@ export class FeedController {
     @Feed(new CustomValidationPipe({ validateCustomDecorators: true }))
     createFeedDto: CreateFeedDto,
   ) {
-    const encryuptedFeedID = await this.feedService.createGroupFeed(
+    const encryptedFeedID = await this.feedService.createGroupFeed(
       createFeedDto,
       [...memberIdList, user.id],
     );
 
-    return encryuptedFeedID;
+    return encryptedFeedID;
   }
 
+  @UseGuards(AuthorizationGuard)
   @Patch('group/:feedId')
   async editGroupFeed(
     @UserReq() user: User,


### PR DESCRIPTION
### 설명
다음의 형식으로 422 HttpException을 내려주도록 수정하였다.

```
{
    "success": false,
    "code": 422,
    "data": {
        "isNotEmpty": "name should not be empty"
    }
}
```