### PR TITLE
Users 컬럼에 `hashedNickname` 컬럼 추가 및 join 로직 수정

### DIFF
--- a/backend/src/entities/User.entity.ts
+++ b/backend/src/entities/User.entity.ts
@@ -37,6 +37,12 @@ export default class User implements UserInterface {
   @Column('bigint', { name: 'kakaoId', unique: true, unsigned: true })
   kakaoId: number;
 
+  @Index({ unique: true })
+  @IsString()
+  @IsNotEmpty()
+  @Column('char', { name: 'hashedNickname', length: 32 })
+  hashedNickname: string;
+
   @DeleteDateColumn()
   deletedAt: Date | null;
 

--- a/backend/src/users/dto/join.request.dto.ts
+++ b/backend/src/users/dto/join.request.dto.ts
@@ -1,15 +1,23 @@
 import { PickType } from '@nestjs/swagger';
 import User from '@root/entities/User.entity';
+import { createHash } from 'crypto';
 
 export default class JoinRequestDto extends PickType(User, [
   'profile',
   'kakaoId',
   'nickname',
 ] as const) {
+  hashedNickname: string;
+
   constructor(nickname: string, kakaoId: number, profile: string) {
     super();
     this.nickname = nickname;
     this.kakaoId = kakaoId;
     this.profile = profile;
+    this.hashedNickname = this.getHashedNickname();
+  }
+
+  getHashedNickname() {
+    return createHash('md5').update(this.nickname).digest('hex');
   }
 }


### PR DESCRIPTION
### 설명
현재 nickname 컬럼에 full-text-index를 적용하여 `닉네임으로 회원 검색` 속도를 줄이고 있습니다.
그런데 nickname 컬럼은 unique constraint 역시 있어야 합니다.
그러나 한 컬럼에 2개의 index를 동시에 접목할 순 없으므로,
`nickname을 해시한 컬럼 hashedNickname을 추가하여 unique constraint는 이걸로 체크` 하도록 하였습니다.

왜 이 선택을 하였는지는 여기 써져 있습니다.
https://auspicious-tarsal-986.notion.site/MySQL-mocking-edd6f5700e7845e0b6a5ce2be2e23d7d

hash 함수는 md5을 사용하였습니다.

### 추가 기능
- User table에 hashedNickname(char, 32) 추가
- joinUserDto 에 hashedNickname 생성 함수 추가 및 `join` 로직 수정