### PR TITLE
refactor: hashedNickname 기반으로 닉네임 중복 조회

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -25,6 +25,7 @@ import JoinRequestDto from '@users/dto/join.request.dto';
 import UserFacade from '@users/users.facade';
 import JoinCookieDto from '@users/dto/join.cookie.dto';
 import ResponseEntity from '@root/common/response/response.entity';
+import { createHash } from 'crypto';
 
 @Controller('users')
 export default class UsersController {
@@ -159,7 +160,9 @@ export default class UsersController {
 
   @Get('check/:nickname')
   async checkDuplicateNickname(@Param('nickname') nickname: string) {
-    const res = await this.userService.getUser({ nickname });
+    const res = await this.userService.getUser({
+      hashedNickname: createHash('md5').update(nickname).digest('hex'),
+    });
     return !res;
   }
 }


### PR DESCRIPTION
### 설명
기존에 nickname 컬럼을 통해 비교하던 중복 조회를 hashedNickname 컬럼 기반 조회로 변경하였다.