### PR TITLE
fix : feed controller 수정

### DIFF
--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Post,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { AccessAuthGuard } from '@root/common/guard/accesstoken.guard';
 
@@ -105,13 +106,13 @@ export class FeedController {
   @Get('scroll/:feedId')
   async getFeedPostingThumbnail(
     @Param('feedId') encryptedId: string,
-    @Body('startPostingId')
-    startPostingId: number,
+    @Query('size') scrollSize: number,
+    @Query('index') startPostingId: number,
   ) {
     const postingThumbnailList = await this.feedService.getPostingThumbnails(
       encryptedId,
       startPostingId,
     );
-    return postingThumbnailList;
+    return ResponseEntity.OK_WITH_DATA(postingThumbnailList);
   }
 }


### PR DESCRIPTION
# 변경 사항
이전
```typescript
  @Get('scroll/:feedId')
  async getFeedPostingThumbnail(
    @Param('feedId') encryptedId: string,
    @Body('startPostingId')
    startPostingId: number,
  ) {
    const postingThumbnailList = await this.feedService.getPostingThumbnails(
      encryptedId,
      startPostingId,
    );
    return postingThumbnailList;
  }
}
```
이후
```typescript
  @Get('scroll/:feedId')
  async getFeedPostingThumbnail(
    @Param('feedId') encryptedId: string,
    @Query('index') startPostingId: number,
  ) {
    const postingThumbnailList = await this.feedService.getPostingThumbnails(
      encryptedId,
      startPostingId,
    );
    return ResponseEntity.OK_WITH_DATA(postingThumbnailList);
  }
}
```
# 변경 이유
-  axios는 get에 body parameter를 넘겨줄 수 없다 -> 때문에 query 로 변경하였다.
- return 값을 responseEntity에 맞게 변경하였다. 