### PR TITLE
fix : user controller 수정

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -101,7 +101,7 @@ export default class UsersController {
       await this.userService.setCurrentRefreshToken(refreshToken, user.id);
       res.cookie('refreshToken', refreshToken, refreshTokenOption);
       res.cookie('accessToken', accessToken, accessTokenOption);
-      return res.redirect('http://localhost:3000/feed');
+      return res.redirect('http://localhost:3000/feeds');
     } catch (e) {
       throw new FailedToLoginKakaoException();
     }
@@ -147,7 +147,7 @@ export default class UsersController {
     await this.userService.setCurrentRefreshToken(refreshToken, user.id);
     res.cookie('refreshToken', refreshToken, refreshTokenOption);
     res.cookie('accessToken', accessToken, accessTokenOption);
-    return res.redirect('http://localhost:3000/feed');
+    res.send(ResponseEntity.CREATED());
   }
 
   @UseGuards(AccessAuthGuard)


### PR DESCRIPTION
# 변경 사항
이전
```typescript
  @Post('join')
  async joinUser(
...
    return res.redirect('http://localhost:3000/feeds')
  }
```
이후
```typescript
  @Post('join')
  async joinUser(
...
    res.send(ResponseEntity.CREATED());
  }
```
# 변경 이유
![Untitled](https://user-images.githubusercontent.com/58061756/206067431-d3bc2e54-4f62-4694-b27d-de620ef677dc.png)
- 이전의 경우 계속 feeds 페이지로 리다이렉트 하는 것을 막았다. 그래서 에러를 리턴했다. 
  ㄴ 이거 도대체 이유가 뭔지 모르겠음... cors 때문인 것 같긴 한데? 다른데는 되는데 왜 여기서만? ㅠㅠ 
  
- 이를 해결하기 위해
  `return ResponseEntity.CREATED()` 로 변경 시도해보았으나 에러 반환 (BAD RESPONSE)
  ![Untitledd](https://user-images.githubusercontent.com/58061756/206067570-a882559b-1569-4359-9bc5-305fdb5a27eb.png)
  그래서 response entity를 `send` 하는 것으로 변경하였는데 
  여기는 왜 칼럼들이 대문자로 시작할까요...?
  nest 정말 어렵네요..  

