### PR TITLE
feat : 중첩 라우팅 경로 설정 및 무한 스크롤 훅 설정

### DIFF
--- a/frontend/src/hooks/useInfiniteScroll.tsx
+++ b/frontend/src/hooks/useInfiniteScroll.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react'
+
+const useInfiniteScroll = (postings: any, callback: () => void) => {
+  const bottomElement = useRef(null)
+  useEffect(() => {
+    if (bottomElement?.current) {
+      const io = new IntersectionObserver(
+        (entries, observer) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              observer.unobserve(entry.target)
+              callback()
+            }
+          })
+        }, {
+          threshold: [1.0]
+        }
+      )
+      io.observe(bottomElement.current)
+      return () => io.disconnect()
+    }
+  }, [postings, bottomElement])
+  return bottomElement
+}
+
+export default useInfiniteScroll

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -14,7 +14,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <BrowserRouter>
     <Routes>
-      <Route path="/Feed" element={<Feed />} />
+      <Route path="/Feed/:feedId" element={<Feed />} />
       <Route path="/Write/:feedId" element={<Write />} />
       <Route path="/SignIn/Info" element={<Info />} />
       <Route path="/SignIn" element={<SignIn />} />

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -14,7 +14,12 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <BrowserRouter>
     <Routes>
-      <Route path="/Feed/:feedId" element={<Feed />} />
+        <Route path="/Feed">
+          <Route path=":feedId" element={<Feed />} />
+          <Route path=":feedId">
+            <Route path=":postingId" element={<Posting />} />
+          </Route>
+        </Route>
       <Route path="/Write/:feedId" element={<Write />} />
       <Route path="/SignIn/Info" element={<Info />} />
       <Route path="/SignIn" element={<SignIn />} />


### PR DESCRIPTION
# 구현
- 중첩 라우팅 경로 설정
  각 포스팅을 `http://localhost:3000/feed/feed해쉬변수/포스팅번호` 로 접근 가능하게 구현
- 무한 스크롤 커스텀 훅 구현
  intersection observer api를 사용해 무한 스크롤이 가능하도록 커스텀 훅을 구현하였다.