### PR TITLE
refactor : cropimg 함수를 콜백 전달 형태에서 return 하는형태로 변경

### DIFF
--- a/frontend/src/pages/Write/index.tsx
+++ b/frontend/src/pages/Write/index.tsx
@@ -40,9 +40,11 @@ const Write = () => {
   const [croppedURL, setCroppedURL] = useState('')
 
   useEffect(() => {
-    if (!isEmpty(images)) {
-      cropImg(images[0].originalImage, setCroppedURL)
-    }
+    if (isEmpty(images)) return
+    void (async () => {
+      const url = await cropImg(images[0].originalImage)
+      setCroppedURL(url)
+    })()
     const canvas = document.querySelector('canvas')
     canvas?.toBlob(
       (blob) => {

--- a/frontend/src/util/cropImg/index.tsx
+++ b/frontend/src/util/cropImg/index.tsx
@@ -1,21 +1,25 @@
-import { Dispatch, SetStateAction } from 'react'
-
-export const cropImg = (file: File, setCroppedURL: Dispatch<SetStateAction<string>>) => {
-  const img = document.createElement('img') as HTMLImageElement
+export const cropImg = async (file: File) => {
   const canvas = document.createElement('canvas') as HTMLCanvasElement
+  const img = (await loadImage(file)) as HTMLImageElement
   const ctx = canvas?.getContext('2d')
-  const src = URL.createObjectURL(file!)
-  img.src = src
-  img.onload = () => {
-    const { width, height } = img
-    const sx = width >= height ? (width - height) / 2 : 0
-    const sy = width <= height ? (height - width) / 2 : 0
-    const min = Math.min(width, height)
-    canvas.width = min
-    canvas.height = min
+  const { width, height } = img
+  const sx = width >= height ? (width - height) / 2 : 0
+  const sy = width <= height ? (height - width) / 2 : 0
+  const min = Math.min(width, height)
+  canvas.width = min
+  canvas.height = min
 
-    ctx?.drawImage(img, sx, sy, min, min, 0, 0, min, min)
-    URL.revokeObjectURL(src)
-    setCroppedURL(canvas.toDataURL())
-  }
+  ctx?.drawImage(img, sx, sy, min, min, 0, 0, min, min)
+  return canvas.toDataURL()
+}
+const loadImage = (file: File) => {
+  const img = document.createElement('img') as HTMLImageElement
+  const src = URL.createObjectURL(file)
+  img.src = src
+  return new Promise((resolve) => {
+    img.onload = () => {
+      URL.revokeObjectURL(src)
+      resolve(img)
+    }
+  })
 }


### PR DESCRIPTION
cropimg 함수를 기존에는 img 태그의 onload 함수안에서 로직이 동작해서 콜백으로 값을 리턴해주는 방식으로 작성했었는데, 
onload를 비동기로 기다리고, 콜백을 사용하지않고, 그냥 리턴해주는 형태로 리펙토링했음.