### PR TITLE
로그인 시 리다이렉트 위치 변경

### DIFF
--- a/backend/dataSource.ts
+++ b/backend/dataSource.ts
@@ -5,7 +5,7 @@ ConfigModule.forRoot();
 
 const dataSource = new DataSource({
   type: 'mysql',
-  host: 'localhost',
+  host: process.env.DB_HOST,
   port: 3306,
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,

--- a/backend/src/feed/feed.utils.ts
+++ b/backend/src/feed/feed.utils.ts
@@ -2,6 +2,7 @@ import { NonExistFeedError } from '@root/custom/customError/serverError';
 import { createCipheriv, createDecipheriv } from 'crypto';
 
 export function encrypt(text: string) {
+  if (!text) return null;
   const iv = Buffer.from(process.env.IV);
   const key = process.env.SECRET_KEY;
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -15,7 +15,7 @@ import { AuthenticationService } from '@root/authentication/authentication.servi
 import { AccessAuthGuard } from '@root/common/guard/accesstoken.guard';
 import { RefreshAuthGuard } from '@root/common/guard/refreshtoken.guard';
 import UsersService from '@users/users.service';
-import { UserReq } from '@users/decorators/users.decorators';
+import usersDecorators, { UserReq } from '@users/decorators/users.decorators';
 import JoinNicknameDto from '@users/dto/join.nickname.dto';
 import JoinRequestDto from '@users/dto/join.request.dto';
 import UserFacade from '@users/users.facade';
@@ -23,6 +23,7 @@ import JoinCookieDto from '@users/dto/join.cookie.dto';
 import ResponseEntity from '@root/common/response/response.entity';
 import User from '@root/entities/User.entity';
 import { createHash } from 'crypto';
+import { encrypt } from '@root/feed/feed.utils';
 
 @Controller('users')
 export default class UsersController {
@@ -93,8 +94,10 @@ export default class UsersController {
     await this.userService.setCurrentRefreshToken(refreshToken, user.id);
     res.cookie('refreshToken', refreshToken, refreshTokenOption);
     res.cookie('accessToken', accessToken, accessTokenOption);
-    const lastVisitedFeed = user.lastVistedFeed;
-    return ResponseEntity.OK_WITH_DATA(lastVisitedFeed);
+    const lastVisitedFeedId = user.lastVistedFeed
+      ? encrypt(user.lastVistedFeed.toString())
+      : '';
+    return res.redirect(`https://localhost:3000/api/feed/${lastVisitedFeedId}`);
   }
 
   @UseGuards(AccessAuthGuard)

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -55,7 +55,7 @@ export default class UsersController {
     await this.userService.setCurrentRefreshToken(refreshToken, user.id);
     res.cookie('refreshToken', refreshToken, refreshTokenOption);
     res.cookie('accessToken', accessToken, accessTokenOption);
-    return res.redirect('http://localhost:3001');
+    return res.redirect(process.env.SERVER_URL_PREFIX);
   }
 
   @Get('kakao')
@@ -78,7 +78,7 @@ export default class UsersController {
         httpOnly: true,
         maxAge: 60 * 60 * 1000,
       });
-      return res.redirect('http://localhost:3000/signin/info');
+      return res.redirect(`${process.env.CLIENT_URL_PREFIX}/signin/info`);
     }
 
     const { accessToken, ...accessTokenOption } =
@@ -97,7 +97,9 @@ export default class UsersController {
     const lastVisitedFeedId = user.lastVistedFeed
       ? encrypt(user.lastVistedFeed.toString())
       : '';
-    return res.redirect(`https://localhost:3000/api/feed/${lastVisitedFeedId}`);
+    return res.redirect(
+      `${process.env.CLIENT_URL_PREFIX}/api/feed/${lastVisitedFeedId}`,
+    );
   }
 
   @UseGuards(AccessAuthGuard)
@@ -106,7 +108,7 @@ export default class UsersController {
     res.clearCookie('refreshToken');
     res.clearCookie('accessToken');
     await this.userService.removeRefreshToken(user.id);
-    return res.redirect('http://localhost:3000');
+    return res.redirect(process.env.CLIENT_URL_PREFIX);
   }
 
   @Post('join')

--- a/frontend/src/pages/SignIn/index.tsx
+++ b/frontend/src/pages/SignIn/index.tsx
@@ -24,12 +24,12 @@ const SignIn = () => {
         <div className="icon-wrapper">
           <XoxoIcon />
         </div>
-          <a href={`${process.env.REACT_APP_SERVER_API as string}/users/kakao`} className='kakao-auth-button'>
-            <div>
-              <KakaoIcon />
-              <span>카카오 로그인</span>
-            </div>
-          </a>
+        <a href={'http://localhost:3001/api/users/kakao'} className="kakao-auth-button">
+          <div>
+            <KakaoIcon />
+            <span>카카오 로그인</span>
+          </div>
+        </a>
       </div>
     </div>
   )


### PR DESCRIPTION
### 설명
기존에 로그인 성공 시 최근 피드 id를 내려주었다.
이를 data를 내려주는 대신, 바로 최근 피드 url 주소로 리다이렉트 시키게 수정하였다.

### 이슈
closed #173 