### PR TITLE
chore: cd 스크립트 추가

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,36 @@
+name: Backend CD Github Action
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀🚀🚀🚀
+on:
+  pull_request:
+    branches:
+      - deploy
+jobs:
+  back-cd-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: backend/node_modules
+          key: ${{ runner.OS }}-master-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - name: dependency install
+        run: npm ci
+
+      - name: build
+        run: npm run build
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: $
+          AWS_SECRET_ACCESS_KEY: $
+        run: |
+          aws --endpoint-url=https://kr.object.ncloudstorage.com  
+          s3 cp --recursive /
+          s3://${{ secrets.NCLOUD_DEPLOY_BUCKET_NAME }}


### PR DESCRIPTION
### 설명
cd github action 스크립트를 추가하였습니다.

### 구조 설명
저희는 현재 auto-scailing을 쓰고 있습니다.
따라서, 시간에 따라 auto-scailing group 의 서버 수 및 ip가 유동적입니다.

따라서, aws의 code deploy와 유사한 ncloud의 source deploy를 사용할 예정입니다.
이를 위해서는 배포 파일을 object storlage에 올려야 하므로, 해당 과정을 cd에서 담당하고 있습니다.