### PR TITLE
refactor: 피드정보 조회시 그룹피드 여부 반환

### DIFF
--- a/backend/src/feed/dto/info.feed.dto.ts
+++ b/backend/src/feed/dto/info.feed.dto.ts
@@ -7,6 +7,7 @@ export default class FeedInfoDto extends PickType(Feed, [
   'thumbnail',
   'description',
   'dueDate',
+  'isGroupFeed',
 ] as const) {
   postingCnt: number;
 


### PR DESCRIPTION
## 설명 

피드 정보를 조회하는 부분에서 groupfeed의 여부를 판단하기 위해서 dto에 isgroupfeed 추가