### PR TITLE
[refactor] db 트랜잭션 병목 현상 해결

### DIFF
--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -29,7 +29,7 @@ export class FeedService {
     await queryRunner.startTransaction();
     try {
       const id = Number(decrypt(encryptedFeedID));
-      const feed = await this.dataSource.getRepository(Feed).find({
+      const feed = await queryRunner.manager.getRepository(Feed).find({
         where: { id },
         relations: ['postings', 'users'],
         select: {
@@ -44,7 +44,7 @@ export class FeedService {
       });
       const feedInfoDto = FeedInfoDto.createFeedInfoDto(feed[0], userId);
       if (feedInfoDto.isOwner) {
-        await this.dataSource
+        await queryRunner.manager
           .getRepository(User)
           .update(userId, { lastVistedFeed: id });
       }


### PR DESCRIPTION
## 설명

피드 정보 조회 api에 동시 접속자를 10명 이상으로 부하를 주었을 때 병목이 발생하는 것을 발견하고 service 레이어의 tx 코드를 변경하는 작업을 진행