### PR TITLE
feat : 닉네임 설정 페이지 중복 확인 기능 구현

### DIFF
--- a/frontend/src/hooks/usePost.tsx
+++ b/frontend/src/hooks/usePost.tsx
@@ -7,8 +7,8 @@ const usePost = (url: string) => {
       try {
         const response = await axios.post(`/api${url}`, body, { ...options, withCredentials: true })
         return response.data
-      } catch (err) {
-        console.log(err)
+      } catch (err: any) {
+        return err.response.data
       }
     },
     [url]

--- a/frontend/src/pages/Info/index.tsx
+++ b/frontend/src/pages/Info/index.tsx
@@ -1,23 +1,47 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import React, { useRef } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
+import useSWR from 'swr'
+import { useNavigate } from 'react-router-dom'
+import { debounce } from 'lodash'
 import './style.scss'
 import usePost from '@hooks/usePost'
 import XoxoIcon from '@assets/xoxoIcon.svg'
 import Input from '@components/Input'
 import SigninBackground from '@components/SigninBackground'
-import { useNavigate } from 'react-router-dom'
+import fetcher from '@util/fetcher'
 import { getWarningNickname } from '@src/util/validation'
 
 const Info = () => {
-  const userNickname = useRef<HTMLInputElement>(null)
-  const postNickname = usePost('/users/join')
   const navigate = useNavigate()
+  const userNickname = useRef<HTMLInputElement>(null)
+  const [nickname, setNickname] = useState('')
+  const [isUniqueNickname, setIsUniqueNickname] = useState<boolean | null>(null)
+  const [isValidNickname, setIsValidNickname] = useState<boolean>(false)
+  const { data: nicknameCheckResult } = useSWR(nickname ? `/users/check/${nickname}` : null, fetcher)
+  const postNickname = usePost('/users/join')
+  const debouncedSearch = debounce((value: string) => {
+    setNickname(value)
+  }, 500)
+
+  useEffect(() => {
+    nicknameCheckResult !== undefined && setIsUniqueNickname(!nicknameCheckResult)
+  }, [nicknameCheckResult])
+
+  useEffect(() => {
+    (nickname === '' || getWarningNickname(nickname) !== '') ? setIsValidNickname(false) : setIsValidNickname(true)
+  }, [nickname])
+
   const handleNicknameForm = async () => {
     if (userNickname.current === null) return
-    const { Success } = await postNickname({ nickname: userNickname.current.value })
-    if (Success) navigate('/feeds')
+    const { success } = await postNickname({ nickname: userNickname.current.value })
+    if (success) navigate('/feeds')
+    else {
+      alert('다시 진행해 주세요.')
+      navigate('/signin')
+    }
   }
+
   return (
     <div className="signin-page">
       <SigninBackground />
@@ -25,11 +49,15 @@ const Info = () => {
         <img className="icon-image" src={XoxoIcon} alt="serviceIcon" />
         <Input
           label="닉네임"
-          placeholder="닉네임을 입력해주세요. ( 조합 10자리 이하)"
+          placeholder="닉네임을 입력해주세요."
           bind={userNickname}
           validate={getWarningNickname}
+          onChangeCb={debouncedSearch}
         />
-        <button className="form-button" onClick={handleNicknameForm}>
+        <div className="nickname-check-wrapper">
+          <div className="nickname-check-result" style={{ color: isUniqueNickname ? '#1ed551' : '#fd4747', height: '16px' }}>{isValidNickname && isUniqueNickname !== null && (isUniqueNickname ? '사용 가능한 닉네임 입니다.' : '중복된 닉네임입니다.')}</div>
+        </div>
+        <button className="form-button" onClick={handleNicknameForm} disabled={!isValidNickname || !isUniqueNickname}>
           시작하기
         </button>
       </div>

--- a/frontend/src/pages/Info/style.scss
+++ b/frontend/src/pages/Info/style.scss
@@ -18,11 +18,26 @@
     @include form-wrapper($white, $white);
     width: 100%;
   }
+  .nickname-check-wrapper{
+    width: 100%;
+    @include vcenter;
+    justify-content: space-between;
+    .nickname-check-result {
+      @include bold(3.13vw, $primary-3);
+      @include not-mobile{
+        @include bold(13px, $white);
+      }
+    }
+  }
   .form-button {
-    @include button-large(#fee500, $black);
-    margin-top: 4vw;
+    @include button-large($primary-3, $white);
+    margin-top: 8vw;
     @include not-mobile{
-      margin-top: 17px;
+      margin-top: 34px;
+    }
+    &:disabled {
+      background-color: $primary-2;
+      color: #c66052
     }
   }
 }


### PR DESCRIPTION
# 구현
![리사이징](https://user-images.githubusercontent.com/58061756/206936686-6bc30315-44fd-472e-b1d2-d20a148aadea.gif)
중복 확인 기능을 구현하였습니다. 
만약 닉네임이 중복이거나, 올바르지 않을 시 버튼을 disable 시키도록 구현하였습니다. 
만약 서버에서 에러를 반환할 경우, 로그인 페이지로 리다이렉트 시키도록 하였습니다. 
- 이유
  - 만약 카카오 로그인 과정 없이 info 페이지로 바로 접근한다면? (현재는 가능함) 
  - 서버측에서 에러를 뱉고, 사용자가 아무리 닉네임을 다시 입력해봤자, 계속 에러만 가게 됨.. 
  - 그럴 상황을 방지해서 일단 에러가 나면 로그인 페이지로 리다이렉트 시키도록 하였는데 다른 생각이 있으시다면 말해주세요~! 
