### PR TITLE
feat : feed 페이지 로직 추가 및 수정

### DIFF
--- a/frontend/src/hooks/useGet.tsx
+++ b/frontend/src/hooks/useGet.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import axios from 'axios'
+
+const useGet = (url: string) => {
+  const post = useCallback(
+    async (options?: object) => {
+      try {
+        const response = await axios.get(`/api${url}`, { ...options, withCredentials: true })
+        return response.data
+      } catch (err) {
+        return err
+      }
+    },
+    [url]
+  )
+
+  return post
+}
+
+export default useGet

--- a/frontend/src/pages/Feed/FeedPostingList/ObserverElement/index.tsx
+++ b/frontend/src/pages/Feed/FeedPostingList/ObserverElement/index.tsx
@@ -6,7 +6,7 @@ const ObserverElement = () => {
   return (
     <div className='observer-element'>
       <div className="arrow">
-        <ArrowIcon width={'4vw'} fill={'#cccccc'}/>
+        <ArrowIcon width={'16px'} fill={'#cccccc'}/>
       </div>
     </div>
   )

--- a/frontend/src/pages/Feed/FeedPostingList/index.tsx
+++ b/frontend/src/pages/Feed/FeedPostingList/index.tsx
@@ -28,30 +28,47 @@ interface IProps {
 const SCROLL_SIZE = 15
 
 const FeedPostingList = ({ isOwner, dueDate, isGroupFeed }: IProps) => {
-  const { feedId } = useParams<{ feedId: string }>()
   const navigate = useNavigate()
+  const { feedId } = useParams<{ feedId: string }>()
+
   const getKey = (pageIndex: number, previousPageData: Iposting[]) => {
     if (previousPageData && !previousPageData.length) return null
-    if (pageIndex === 0) return `/feed/scroll/${feedId}?size=${SCROLL_SIZE}&index=${pageIndex}`
+    if (pageIndex === 0) return `/feed/scroll/${feedId}?size=${isGroupFeed ? SCROLL_SIZE - 1 : (isOwner ? SCROLL_SIZE : SCROLL_SIZE - 1)}&index=${pageIndex}`
     return `/feed/scroll/${feedId}?size=${SCROLL_SIZE}&index=${previousPageData[previousPageData.length - 1].id}`
   }
   const { data: postings, error, size, setSize } = useSWRInfinite(getKey, fetcher, { initialSize: 1, revalidateFirstPage: false })
+
   // 리스트 로딩중일 때
   const isLoading = (!postings && !error) || (size > 0 && postings && typeof postings[size - 1] === 'undefined')
   // 리스트를 정상적으로 받아왔지만 비어있을 경우 (게시글이 작성되지 않았을 경우)
   const isEmpty = postings?.[0]?.length === 0
-  // 리스트를 끝까지 읽었을 경우
-  const isReachingEnd = (postings != null) && postings[postings.length - 1]?.length < SCROLL_SIZE
+  // 쓰기 버튼이 존재할때 리스트의 끝에 도달했는지 판단
+  const isExistWriteButton = (postings != null) && ((postings.length === 1 && postings[0].length < SCROLL_SIZE - 1) || (postings.length > 1 && postings[postings.length - 1].length < SCROLL_SIZE))
+  // 쓰기 버튼이 존재하지 않을 때 리스트의 끝에 도달했는지 판단
+  const isNotExistWriteButton = (postings != null) && (postings[postings.length - 1].length < SCROLL_SIZE)
+  // 그룹피드, 개인 피드의 주인, 개인 피드의 주인이 아닐 때 리스트의 끝에 도달했는지 판단
+  const isReachingEnd = (isGroupFeed && isExistWriteButton) || (!isGroupFeed && !isOwner && isExistWriteButton) || (!isGroupFeed && isOwner && isNotExistWriteButton)
+
   const bottomElement = useInfiniteScroll(postings, () => {
     !isReachingEnd && setSize(size => size + 1)
   })
-  const checkDueDate = (id: string) => {
-    // TODO - 현재는 그냥 클라이언트 상에서 확인하지만, 서버 시간을 확인해서 진행할지? 논의 진행해야함
-    isFuture(dueDate) ? toast(`게시물이 공개되기까지 ${remainDueDate(dueDate)} 남았어요`) : navigate(`${id}`)
+
+  useEffect(() => {
+    if (isEmpty) toast('아직 작성된 포스팅이 없습니다')
+  }, [isEmpty])
+
+  const checkReadable = (id: string) => {
+    if (!isOwner) {
+      toast('피드의 주인만 포스팅을 열람할 수 있습니다.')
+    } else if (isFuture(dueDate)) {
+      toast(`게시물이 공개되기까지 ${remainDueDate(dueDate)} 남았어요`)
+    } else navigate(`${id}`)
   }
+
   const postingList = postings?.flat().map((posting: Iposting) => {
+    console.log(isLoading, isEmpty, isReachingEnd, postings, isOwner, isGroupFeed, (isGroupFeed || (!isOwner && !isGroupFeed)), postings[0]?.length < SCROLL_SIZE - 1)
     return (
-    <button key={posting.id} className="posting-container" onClick={() => checkDueDate(posting.id)} >
+    <button key={posting.id} className="posting-container" onClick={() => checkReadable(posting.id)} >
       <img key={posting.id}
         className="posting"
         src={posting.thumbanil}
@@ -59,23 +76,19 @@ const FeedPostingList = ({ isOwner, dueDate, isGroupFeed }: IProps) => {
     </button>
     )
   })
-  const writePostingButton = () => {
-    return (
-      <Link className="write-posting-container" to={`/write/${feedId}`}>
-        <div className='write-posting-button'>
-          <PlusIcon width={'5vw'}/>
-        </div>
-      </Link>
-    )
-  }
-  useEffect(() => {
-    if (isEmpty) toast('아직 작성된 포스팅이 없습니다')
-  }, [isEmpty])
+
+  const writePostingButton =
+  <Link className="write-posting-container" to={`/write/${feedId}`}>
+    <div className='write-posting-button'>
+      <PlusIcon width={'5vw'}/>
+    </div>
+  </Link>
+
   return (
     <div className='posting-list-wrapper'>
     <div>
       <div className="posting-grid">
-        {isGroupFeed ? writePostingButton() : !isOwner && writePostingButton() }
+        {isGroupFeed ? writePostingButton : !isOwner && writePostingButton }
         {!isEmpty && postingList}
       </div>
     </div>

--- a/frontend/src/pages/Feed/FeedProfile/index.tsx
+++ b/frontend/src/pages/Feed/FeedProfile/index.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import React, { useEffect } from 'react'
+import useSWR from 'swr'
 import './style.scss'
 import { ReactComponent as ShareIcon } from '@assets/shareIcon.svg'
 import { ReactComponent as EditIcon } from '@assets/editIcon.svg'
 import DefaultUserImage from '@assets/defaultUserImage.svg'
 import { remainDueDate } from '@util/index'
+import fetcher from '@util/fetcher'
 
 interface IProps {
   thumbnail: string
@@ -16,6 +18,7 @@ interface IProps {
 }
 
 const FeedProfile = ({ thumbnail, description, dueDate, postingCnt, isOwner, isGroupFeed }: IProps) => {
+  const { data: serverDate } = useSWR('/serverTime', fetcher)
   const kakaoJavascriptKey = process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY
   const kakaoMessageTemplate = Number(process.env.REACT_APP_KAKAO_MESSAGE_TEMPLATE)
   useEffect(() => {
@@ -46,7 +49,7 @@ const FeedProfile = ({ thumbnail, description, dueDate, postingCnt, isOwner, isG
                 <div className="feed-profile-status">
                     <span className="feed-post-number">게시물 수 <span className="bold">{postingCnt}</span></span>
                     <span className="line"></span>
-                    <span className="feed-remaining-time">남은 시간 <span className="bold">{remainDueDate(dueDate)}</span></span>
+                    <span className="feed-remaining-time">남은 시간 <span className="bold">{remainDueDate(dueDate, serverDate)}</span></span>
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -22,16 +22,22 @@ const MainPage = () => {
   const navigate = useNavigate()
   const { feedId } = useParams<{ feedId: string }>()
   const { data: feedInfo, error: feedError } = useSWR<IFeedInfo>(feedId !== undefined ? `/feed/info/${feedId}` : null, fetcher)
+
+  // 올바른 경로가 아닐 때 (feed 정보를 불러오는데에 실패 했을 때)
   useEffect(() => {
-    // 올바른 경로가 아니라면 에러를 404 페이지로 리다이렉트
-    if (feedError) {
-      console.log(feedError)
-    }
+    navigate('/404')
   }, [feedError])
+
+  // 그룹 피드의 주인이 아닐 때
   useEffect(() => {
-    // TODO - 그룹 피드의 일원이 아닐 경우 일단 404로 옮겨놨는데, 권한 없는 페이지 안내하는걸 만들지? 아니면 뒤로가기 시킬지 논의해봐야함
-    if (feedInfo?.isGroupFeed && !feedInfo?.isOwner) navigate('/404')
+    if (feedInfo) feedInfo.isGroupFeed && !feedInfo.isOwner && navigate('/404')
   }, [feedInfo])
+
+  // feedId를 쓰지 않았을 때 '/feed'로 접근했을 때
+  useEffect(() => {
+    if (!feedId) navigate('/404')
+  }, [feedId])
+
   return (
     <>
     {

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -21,12 +21,11 @@ interface IFeedInfo {
 const MainPage = () => {
   const navigate = useNavigate()
   const { feedId } = useParams<{ feedId: string }>()
-  const { data: feedInfo, error: feedError } = useSWR<IFeedInfo>(`/feed/info/${feedId}`, fetcher)
+  const { data: feedInfo, error: feedError } = useSWR<IFeedInfo>(feedId !== undefined ? `/feed/info/${feedId}` : null, fetcher)
   useEffect(() => {
     // 올바른 경로가 아니라면 에러를 404 페이지로 리다이렉트
     if (feedError) {
-      const { error } = feedError.response.data.data
-      if (error === 'NonExistFeedIdException') navigate('/404')
+      console.log(feedError)
     }
   }, [feedError])
   useEffect(() => {

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -25,17 +25,17 @@ const MainPage = () => {
 
   // 올바른 경로가 아닐 때 (feed 정보를 불러오는데에 실패 했을 때)
   useEffect(() => {
-    navigate('/404')
+    if (feedError !== undefined) navigate('/404')
   }, [feedError])
 
   // 그룹 피드의 주인이 아닐 때
   useEffect(() => {
-    if (feedInfo) feedInfo.isGroupFeed && !feedInfo.isOwner && navigate('/404')
+    if (feedInfo !== undefined) feedInfo.isGroupFeed && !feedInfo.isOwner && navigate('/404')
   }, [feedInfo])
 
   // feedId를 쓰지 않았을 때 '/feed'로 접근했을 때
   useEffect(() => {
-    if (!feedId) navigate('/404')
+    if (feedId === undefined) navigate('/404')
   }, [feedId])
 
   return (

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -6,9 +6,9 @@ export const yyyymmdd = (date: Date) =>
   `${date.getFullYear()}-${date.getMonth() + 1 < 9 ? `0${date.getMonth() + 1}` : date.getMonth() + 1}-${
     date.getDate() < 9 ? `0${date.getDate()}` : date.getDate()
   }`
-export const remainDueDate = (dueDate: string) => {
+export const remainDueDate = (dueDate: string, serverDate: string) => {
   const future = new Date(dueDate)
-  const present = new Date()
+  const present = new Date(serverDate)
   const diff = future.getTime() - present.getTime()
   const diffDay = Math.floor(diff / (1000 * 60 * 60 * 24))
   const diffHour = Math.floor((diff / (1000 * 60 * 60)) % 24)

--- a/frontend/src/util/validation/bool.ts
+++ b/frontend/src/util/validation/bool.ts
@@ -10,4 +10,5 @@ export const containsEmoji = (str: string) =>
     str
   )
 export const isFuture = (date: string) => new Date(yyyymmdd(new Date())) < new Date(date)
+export const isFutureRatherThanServer = (dueDate: string, serverDate: string) => new Date(serverDate) < new Date(dueDate)
 export const isYYYYMMDD = (date: string) => /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/.test(date)


### PR DESCRIPTION
# 구현
feed 페이지의 로직을 추가 및 수정하였습니다. 
- 피드 페이지 에러 로직 수정
  -  '/feed' 로 접근 했을 때, 즉 feedId를 명시하지 않았을 때 404 페이지로 이동
  - 올바른 feedId를 주지 않았을 때 404 페이지로 이동
  - 그룹 피드의 주인(=일원)이 아닐 때 404 페이지로 이동 
- 피드의 주인이 아닐 경우, 포스팅을 클릭했을 때 '피드의 주인만 볼 수 있습니다.'라는 포스팅 띄우기
- 글쓰기 버튼이 존재할 경우 처음 포스팅을 14개만 받아오도록 수정
  - 그에 따른 포스팅 끝 판단하는 로직을 변경하게 되었습니다. 
 