### PR TITLE
Refactor/createfeed button&component/fe/gh

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -25,7 +25,8 @@ root.render(
       <Route path="/SignIn/Info" element={<SigninRoute Component={Info} />} />
       <Route path="/SignIn" element={<SigninRoute Component={SignIn} />} />
       <Route path="/Createfeed/:path" element={<AuthRoute Component={CreateFeed} />} />
-      <Route path="/Feeds" element={<Feeds />} />
+      <Route path="/Feeds" element={<AuthRoute Component={Feeds} />} />
+      <Route path="/Posting" element={<Posting />} />
       <Route path="/*" element={<Error />} />
     </Routes>
   </BrowserRouter>

--- a/frontend/src/pages/CreateFeed/CreateFeedButton/index.tsx
+++ b/frontend/src/pages/CreateFeed/CreateFeedButton/index.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { useState } from 'react'
+import usePost from '@hooks/usePost'
+import { IResponse } from '@src/types'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ICreateFeedButton } from '../types'
+import { isEmpty } from 'lodash'
+
+const CreateFeedButton = ({ getFeedInfos }: ICreateFeedButton) => {
+  const postPersonalFeed = usePost('/feed')
+  const postGroupFeed = usePost('/feed/group')
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false)
+  const { path } = useParams<{ path: string }>()
+  const navigate = useNavigate()
+  const onFeedBtnClicked = async () => {
+    setIsButtonDisabled(true)
+    const formData = await getFeedInfos()
+    if (isEmpty(formData)) {
+      setIsButtonDisabled(false)
+      return
+    }
+    if (path === 'personal') {
+      const { success, data }: IResponse = await postPersonalFeed(formData)
+      if (success) navigate(`/Feed/${data as string}`)
+    }
+    if (path === 'group') {
+      const { success, data }: IResponse = await postGroupFeed(formData)
+      if (success) navigate(`/Feed/${data as string}`)
+    }
+  }
+  return (
+    <button className="button-large" onClick={onFeedBtnClicked} disabled={isButtonDisabled}>
+      피드 생성하기
+    </button>
+  )
+}
+
+export default CreateFeedButton

--- a/frontend/src/pages/CreateFeed/GroupMember/Suggestions.tsx
+++ b/frontend/src/pages/CreateFeed/GroupMember/Suggestions.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import useSWR from 'swr'
 import fetcher from '@src/util/fetcher'
 import { isEmpty } from 'lodash'
-import { ISuggestion } from '@src/types'
+import { ISuggestion } from '../types'
 interface ISuggestions {
   nickname: string
   setMembers: (s: ISuggestion) => void

--- a/frontend/src/pages/CreateFeed/GroupMember/index.tsx
+++ b/frontend/src/pages/CreateFeed/GroupMember/index.tsx
@@ -3,12 +3,7 @@ import React, { useRef, useState } from 'react'
 import { ReactComponent as XIcon } from '@assets/XIcon.svg'
 import Suggestions from './Suggestions'
 import Input from '@src/components/Input'
-import { ISuggestion } from '@src/types'
-
-interface IGroupMember {
-  members: ISuggestion[]
-  setMembers: React.Dispatch<React.SetStateAction<ISuggestion[]>>
-}
+import { IGroupMember, ISuggestion } from '../types'
 
 const GroupMember = ({ members, setMembers }: IGroupMember) => {
   const nicknameRef = useRef<HTMLInputElement>(null)

--- a/frontend/src/pages/CreateFeed/index.tsx
+++ b/frontend/src/pages/CreateFeed/index.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/member-delimiter-style */
-/* eslint-disable @typescript-eslint/dot-notation */
-/* eslint-disable @typescript-eslint/no-misused-promises */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useRef, useState } from 'react'
 import './style.scss'
 
@@ -9,51 +5,36 @@ import defaultUserImage from '@assets/defaultUserImage.svg'
 import Header from '@src/components/Header'
 import Input from '@src/components/Input'
 import GroupMember from './GroupMember'
-import { compressImage } from '@src/util/imageCompress'
-import usePost from '@hooks/usePost'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   getWarningDuedate,
   getWarningDescription,
   getWarningName,
-  validName,
+  getWarningMembers,
   validDescription,
   validDuedate,
   validMembers,
-  getWarningMembers
+  validName
 } from '@src/util/validation'
 import Toast from '@src/components/Toast'
-import { toast } from 'react-toastify'
 import { isEmpty } from 'lodash'
-import { ISuggestion } from '@src/types'
-import { yyyymmdd } from '@src/util'
-
-interface ICreateFeed {
-  path: string
-}
-
-interface feedForm {
-  name?: string
-  thumbnail?: string
-  description?: string
-  dueDate?: string
-  memberIdList?: number[]
-}
+import CreateFeedButton from './CreateFeedButton'
+import { IFeedForm, ISuggestion } from './types'
+import { toast } from 'react-toastify'
+import { uploadImage } from '@src/util/uploadImage'
+import usePost from '@src/hooks/usePost'
 
 const CreateFeed = () => {
   const nameRef = useRef<HTMLInputElement>(null)
   const [thumbnail, setThumbnail] = useState<File>()
   const descriptionRef = useRef<HTMLInputElement>(null)
   const dueDateRef = useRef<HTMLInputElement>(null)
-
   const [members, setMembers] = useState<ISuggestion[]>([])
 
-  const feedThumbnail = useRef<HTMLInputElement>(null)
+  const thumbnailInput = useRef<HTMLInputElement>(null)
   const [thumbnailSrc, setThumbnailSrc] = useState('')
-  const postImage = usePost('/image')
-  const postPersonalFeed = usePost('/feed')
-  const postGroupFeed = usePost('/feed/group')
   const navigate = useNavigate()
+  const postImage = usePost('/image')
 
   const { path } = useParams<{ path: string }>()
 
@@ -61,81 +42,57 @@ const CreateFeed = () => {
     if (!(path === 'group' || path === 'personal')) navigate('/404')
   }, [path])
 
-  useEffect(() => {
-    if (!isEmpty(dueDateRef.current)) {
-      const min = new Date()
-      min.setDate(min.getDate() + 1)
-      dueDateRef.current.min = yyyymmdd(min)
-    }
-  })
-
-  const onChangeFeedThumbnail = async (e: any) => {
-    const url = URL.createObjectURL(e.target.files[0])
-    setThumbnailSrc(url)
-
-    const compressedImage = await compressImage(e.target.files[0])
-    setThumbnail(compressedImage)
+  const onChangeFeedThumbnail = (e: any) => {
+    setThumbnail(e.target.files[0])
+    setThumbnailSrc(URL.createObjectURL(e.target.files[0]))
   }
 
   const onThumbnailUploadClicked = (e: any) => {
-    if (!isEmpty(feedThumbnail.current)) feedThumbnail.current.click()
+    if (!isEmpty(thumbnailInput.current)) thumbnailInput.current.click()
   }
-
-  const onFeedBtnClicked = async () => {
+  const getFeedInfos = async (): Promise<IFeedForm | undefined> => {
     if (isEmpty(nameRef.current) || isEmpty(descriptionRef.current) || isEmpty(dueDateRef.current)) {
       toast('페이지에 오류가 있습니다. 새로고침 후 다시 작성해주세요.')
-      return
+      return undefined
     }
-    const formData: feedForm = {}
-
-    if (validName(nameRef.current.value)) formData.name = nameRef.current.value
-    else {
+    if (!validName(nameRef.current.value)) {
       toast(getWarningName(nameRef.current.value))
-      return
+      return undefined
     }
 
-    if (validDescription(descriptionRef.current.value)) formData.description = descriptionRef.current.value
-    else {
-      toast(getWarningDescription(nameRef.current.value))
-      return
+    if (!validDescription(descriptionRef.current.value)) {
+      toast(getWarningDescription(descriptionRef.current.value))
+      return undefined
     }
 
-    if (validDuedate(dueDateRef.current.value)) formData.dueDate = dueDateRef.current.value
-    else {
+    if (validDuedate(dueDateRef.current.value)) {
       toast(getWarningDuedate(dueDateRef.current.value))
-      return
+      return undefined
     }
 
-    const [thumbnail] = await uploadImage()
-    formData.thumbnail = thumbnail
+    if (path === 'group' && !validMembers(members!)) {
+      toast(getWarningMembers(members!))
+      return undefined
+    }
 
-    if (path === 'group') {
-      if (validMembers(members)) {
-        const memberIdList = members.map(({ id }) => Number(id))
-        formData.memberIdList = memberIdList
-      } else {
-        toast(getWarningMembers(members))
-      }
+    const formData: IFeedForm = {
+      name: nameRef.current.value,
+      description: descriptionRef.current.value,
+      dueDate: dueDateRef.current.value,
+      thumbnail: await getThumbnailUrl()
     }
-    console.log(formData)
-
-    if (path === 'personal') {
-      const { success, data }: { success: boolean; data: string } = await postPersonalFeed(formData)
-      if (success) navigate(`/Feed/${data}`)
-    }
-    if (path === 'group') {
-      const { success, data }: { success: boolean; data: string } = await postGroupFeed(formData)
-      if (success) navigate(`/Feed/${data}`)
-    }
+    const memberIdList = getMembers()
+    if (!isEmpty(members)) formData.memberIdList = memberIdList
+    return formData
   }
-
-  const uploadImage = async () => {
-    const formData = new FormData()
-    if (isEmpty(thumbnail)) return ''
-    formData.append('image', thumbnail)
-    const { success, data } = await postImage(formData)
-    if (success === false) toast('이미지 업로드 중 문제가 발생했습니다.')
-    return data
+  const getThumbnailUrl = async () => {
+    if (thumbnail === undefined) return ''
+    const [thumbnailUrl] = await uploadImage([thumbnail], postImage)
+    return thumbnailUrl as string
+  }
+  const getMembers = () => {
+    if (path !== 'group') return undefined
+    return members.map(({ id }) => Number(id))
   }
   return (
     <div className="createfeed-page">
@@ -146,7 +103,7 @@ const CreateFeed = () => {
             <div className="profile-pic-circle">
               <img
                 src={thumbnailSrc}
-                alt=""
+                alt="프로필 썸네일 미리보기"
                 onLoad={() => {
                   URL.revokeObjectURL(thumbnailSrc)
                 }}
@@ -157,7 +114,7 @@ const CreateFeed = () => {
             </div>
             <span>피드 사진 생성</span>
           </button>
-          <input type="file" accept="image/*" ref={feedThumbnail} onChange={onChangeFeedThumbnail} />
+          <input type="file" accept="image/*" ref={thumbnailInput} onChange={onChangeFeedThumbnail} />
         </div>
         <Input label="제목" placeholder="피드의 제목을 입력해주세요" bind={nameRef} validate={getWarningName} />
         <Input
@@ -174,9 +131,7 @@ const CreateFeed = () => {
           validate={getWarningDuedate}
         />
         {path === 'group' && <GroupMember members={members} setMembers={setMembers} />}
-        <button className="button-large" onClick={onFeedBtnClicked}>
-          피드 생성하기
-        </button>
+        <CreateFeedButton getFeedInfos={getFeedInfos} />
         <Toast />
       </div>
     </div>

--- a/frontend/src/pages/CreateFeed/types.ts
+++ b/frontend/src/pages/CreateFeed/types.ts
@@ -1,0 +1,18 @@
+export interface IFeedForm {
+  name?: string
+  thumbnail?: string
+  description?: string
+  dueDate?: string
+  memberIdList?: number[]
+}
+export interface ISuggestion {
+  id: string
+  nickname: string
+}
+export interface IGroupMember {
+  members: ISuggestion[]
+  setMembers: React.Dispatch<React.SetStateAction<ISuggestion[]>>
+}
+export interface ICreateFeedButton {
+  getFeedInfos: () => Promise<IFeedForm | undefined>
+}

--- a/frontend/src/pages/Posting/ImageSlider/ImageCard.tsx
+++ b/frontend/src/pages/Posting/ImageSlider/ImageCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-interface IImageCard {
-  src: string
-}
+import { IImageCard } from './types'
+
 const ImageCard = ({ src }: IImageCard) => {
   return (
     <div key={src} className="image-container">

--- a/frontend/src/pages/Posting/ImageSlider/imageQuery.ts
+++ b/frontend/src/pages/Posting/ImageSlider/imageQuery.ts
@@ -1,0 +1,23 @@
+export const getthumbUrl = (url: string) => {
+  return `${url}${getQueryString(true)}`
+}
+export const getoriginalUrl = (url: string) => {
+  return `${url}${getQueryString(false)}`
+}
+const getQueryString = (isLq: boolean) => {
+  const windowWidth = window.innerWidth
+  const size = isLq ? getThumbSize(windowWidth) : getOriginalSize(windowWidth)
+  return `?type=m&w=${size}&h=${size}`
+}
+const getOriginalSize = (widdowWidth: number) => {
+  const level = Math.floor(widdowWidth / 100)
+  if (level >= 5) return 500
+  if (level >= 4) return 400
+  return 300
+}
+const getThumbSize = (widdowWidth: number) => {
+  const level = Math.floor(widdowWidth / 100)
+  if (level >= 5) return 50
+  if (level >= 4) return 40
+  return 30
+}

--- a/frontend/src/pages/Posting/ImageSlider/index.tsx
+++ b/frontend/src/pages/Posting/ImageSlider/index.tsx
@@ -1,22 +1,38 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 import ImageCard from './ImageCard'
+import { IImageCard } from './types'
+import { getoriginalUrl, getthumbUrl } from './imageQuery'
 
 interface IImageSlider {
   images: string[]
 }
-const settings = {
-  dots: true,
-  infinite: true,
-  speed: 500,
-  slidesToShow: 1,
-  slidesToScroll: 1,
-  arrows: false
-}
 const ImageSlider = ({ images }: IImageSlider) => {
-  const imageCards = images.map((src: string) => <ImageCard src={src} key={src} />)
+  const [page, setPage] = useState(0)
+  const [imageStatus, setImageStatus] = useState<IImageCard[]>(
+    images.map((url, index): IImageCard => {
+      return {
+        src: index < 2 ? getoriginalUrl(url) : getthumbUrl(url),
+        url,
+        isLq: !(index < 2),
+        index
+      }
+    })
+  )
+  const imageCards = images.map(({ src }: IImageCard) => <ImageCard src={src} key={src} />)
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: false,
+    beforeChange: (_, index: number) => {
+      setPage(index)
+    }
+  }
   return (
     <div className="image-carousel-container">
       <Slider {...settings}>{imageCards}</Slider>

--- a/frontend/src/pages/Posting/ImageSlider/types.tsx
+++ b/frontend/src/pages/Posting/ImageSlider/types.tsx
@@ -1,0 +1,6 @@
+export interface IImageCard {
+  src: string
+  url: string
+  isLq: boolean
+  index: number
+}

--- a/frontend/src/pages/Posting/index.tsx
+++ b/frontend/src/pages/Posting/index.tsx
@@ -6,6 +6,7 @@ import defaultUserImage from '@assets/defaultUserImage.svg'
 import useSWR from 'swr'
 import { useParams } from 'react-router-dom'
 import ImageSlider from './ImageSlider'
+
 const Posting = () => {
   const { feedId, postingId } = useParams()
   const {
@@ -16,7 +17,6 @@ const Posting = () => {
       sender: { nickname, thumbnail }
     }
   } = useSWR(`/posting/${feedId!}/${postingId!}`)
-
   return (
     <div className="posting-page">
       <Header page="posting" text={name} />


### PR DESCRIPTION
* 관심사 분리를 위해 버튼 컴포넌트를 분리
버튼 컴포넌트는 페이지에서 업로드 할 내용을 리턴해주는 getter 함수를 인자로 받도록 설계함.
이 getter 함수에서 업로드를 해도 되는 내용인지 검증을 하고, 
업로드를 해도 된다면 업로드 인터페이스에 맞춰 리턴해주고, 
할수 없다면 토스트 메시지를 띄우고 undefined를 리턴한다.
버튼 컴포넌트에서는 getter 함수가 리턴하는 값이 undefined 라면 동작하지않고, 비어있지 않다면 동작하도록 설계했다. 
* 인터페이스를 createfeed 안 types.ts에서 보관하도록 변경
* createfeed 페이지에 분리한 버튼 컴포넌트 적용