### PR TITLE
fix: cors 문제 해결 위해 cookie option에 domain 추가

### DIFF
--- a/backend/src/users/dto/cookie.info.dto.ts
+++ b/backend/src/users/dto/cookie.info.dto.ts
@@ -28,6 +28,6 @@ export default class CookieDto {
   }
 
   get option() {
-    return { domain: process.env.CLIENT_URL_PREFIX, ...this.Option };
+    return { domain: process.env.SERVICE_DOMAIN, ...this.Option };
   }
 }


### PR DESCRIPTION
### 설명
기존 api 서버와 프론트 서버의 도메인 주소(ip 주소) 가 달라 cors 문제가 발생하였다.
그런데, 만약 두 서버의 서브 도메인이 같다면,
즉 같은 도메인을 공유하고 호스트만 다르다면 cors 문제를 해결할 수 있다는 글을 보았다.

그래서 각각의 서버에 동일한 도메인(ourmemoryxoxo.me)를 등록해주고,
cookie 설정에 해당 도메인으로 `domain` 옵션을 추가해주니 잘 되었다.