### PR TITLE
fix: 로그아웃 쿠키 삭제 안되던 문제 해결

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -70,8 +70,8 @@ export default class UsersController {
     @UserReq() user: User,
     @Res({ passthrough: true }) res: Response,
   ) {
-    res.clearCookie('refreshToken');
-    res.clearCookie('accessToken');
+    res.clearCookie('refreshToken', { domain: process.env.SERVICE_DOMAIN });
+    res.clearCookie('accessToken', { domain: process.env.SERVICE_DOMAIN });
     await this.userService.removeRefreshToken(user.id);
     return ResponseDto.CREATED_WITH_DATA(true);
   }


### PR DESCRIPTION
### 설명
쿠키 전달 과정에서 발생한 CORS 문제를 해결하기 위하여 subdomain 방식을 사용하였다.
그래서 쿠키를 생성할 때, `domain` 이라는 옵션을 추가하였는데, 로그아웃 시 `res.clearCookie` 가 안되는 이슈가 발생하였다.
찾아보니 쿠키를 삭제할 때에도 `domain`을 명시해 주면 해결되는 문제여서, `domain` 옵션을 `clearCookie` 에 추가해주었다.

[참고자료]
https://github.com/expressjs/express/issues/691
