### PR TITLE
refactor: 피드 정보 조회 부분 조인 해제 후 최적화 시도

### DIFF
--- a/backend/src/feed/dto/info.feed.dto.ts
+++ b/backend/src/feed/dto/info.feed.dto.ts
@@ -1,6 +1,7 @@
 import { PickType } from '@nestjs/swagger';
 import { NonExistFeedError } from '@root/custom/customError/serverError';
 import { Feed } from '@root/entities/Feed.entity';
+import UserFeedMapping from '@root/entities/UserFeedMapping.entity';
 
 export default class FeedInfoDto extends PickType(Feed, [
   'name',
@@ -13,7 +14,7 @@ export default class FeedInfoDto extends PickType(Feed, [
 
   isOwner: boolean;
 
-  constructor(feed: Feed, userId: number) {
+  constructor(feed: Feed, user: UserFeedMapping) {
     super();
     this.name = feed.name;
     this.thumbnail = feed.thumbnail;
@@ -21,21 +22,20 @@ export default class FeedInfoDto extends PickType(Feed, [
     this.dueDate = feed.dueDate;
     this.isGroupFeed = feed.isGroupFeed;
     this.getPostingCnt(feed.postings);
-    this.checkIsOwner(feed.users, userId);
+    this.checkIsOwner(user);
   }
 
   getPostingCnt(postingArray: { id: number }[]) {
     this.postingCnt = postingArray.length;
   }
 
-  checkIsOwner(users: { userId: number }[], userID: number) {
-    const userIdList = users.map((obj) => obj.userId);
-    const isOwner = userIdList.includes(userID);
-    this.isOwner = isOwner;
+  checkIsOwner(user: UserFeedMapping) {
+    if (!user) this.isOwner = false;
+    else this.isOwner = true;
   }
 
-  static createFeedInfoDto(feed, userId: number) {
+  static createFeedInfoDto(feed: Feed, user: UserFeedMapping) {
     if (!feed) throw new NonExistFeedError();
-    return new FeedInfoDto(feed, userId);
+    return new FeedInfoDto(feed, user);
   }
 }

--- a/backend/src/feed/feed.repository.ts
+++ b/backend/src/feed/feed.repository.ts
@@ -6,23 +6,6 @@ import FindFeedDto from './dto/find.feed.dto';
 
 @CustomRepository(Feed)
 export class FeedRepository extends Repository<Feed> {
-  async getFeed(id: number) {
-    const feed = this.find({
-      where: { id },
-      relations: ['postings', 'users'],
-      select: {
-        postings: { id: true },
-        users: { userId: true },
-        name: true,
-        description: true,
-        thumbnail: true,
-        dueDate: true,
-        isGroupFeed: true,
-      },
-    });
-    return feed;
-  }
-
   async getFeedByFindFeedDto(findFeedDto: FindFeedDto) {
     const feed = await this.find({ where: findFeedDto });
     return feed;


### PR DESCRIPTION
## 설명
피드 정보 조회부분에서 테이블 3개를 조인해서 결과를 내는 쿼리문이 있었다. 
부하테스트를 진행하면서 해당하는 쿼리문에 시간이 많이 소요되고 있는 것을 파악후, 조인 연산을 줄이는 식으로 쿼리 최적화를 시도하였다. 

user-mapping table의 userId, feedId 가 pk 이므로, 해당하는 pk 값으로 한번에 원하는 값을 조회할 수 있다. 
굳이 조인연산을 사용하여 해당하는 피드의 주인이 맞는지의 유무를 확인하지 않고, user-feed-mapping table에서 한번의 search로 원하는 결과를 얻을 수 있다. 