### PR TITLE
fix: 엔티티 규약 통일

### DIFF
--- a/backend/src/custom/customValidators/nicknameValidate.ts
+++ b/backend/src/custom/customValidators/nicknameValidate.ts
@@ -12,7 +12,7 @@ import {
 export class InvalidNickname implements ValidatorConstraintInterface {
   async validate(nickname: string, args: ValidationArguments) {
     if (!nickname) return false;
-    return nickname.length < 10;
+    return nickname.length <= 15;
   }
 
   defaultMessage(args: ValidationArguments) {

--- a/backend/src/entities/Feed.entity.ts
+++ b/backend/src/entities/Feed.entity.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsUrl } from 'class-validator';
+import { IsNotEmpty, IsUrl, MaxLength } from 'class-validator';
 
 import {
   Entity,
@@ -27,7 +27,8 @@ export class Feed implements FeedInterface {
   thumbnail: string;
 
   @IsNotEmpty()
-  @Column({ type: 'varchar', nullable: false })
+  @MaxLength(100)
+  @Column({ type: 'varchar', length: 100, nullable: false })
   description: string;
 
   @IsNotEmpty()

--- a/backend/src/entities/Posting.entity.ts
+++ b/backend/src/entities/Posting.entity.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumberString, IsString, IsUrl } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumberString,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -21,7 +27,8 @@ export default class Posting implements PostingInterface {
 
   @IsNotEmpty()
   @IsString()
-  @Column('varchar')
+  @MaxLength(2000)
+  @Column({ type: 'text' })
   letter: string;
 
   @IsNotEmpty()

--- a/backend/src/users/users.facade.ts
+++ b/backend/src/users/users.facade.ts
@@ -4,7 +4,6 @@ import JoinCookieDto from '@users/dto/join.cookie.dto';
 import UsersService from '@users/users.service';
 import { AuthenticationService } from '@root/authentication/authentication.service';
 import { encrypt } from '@root/feed/feed.utils';
-import { createHash } from 'crypto';
 import { OauthService } from '../oauth/oauth.service';
 import JoinRequestDto from './dto/join.request.dto';
 import CookieDto from './dto/cookie.info.dto';
@@ -105,14 +104,14 @@ export default class UserFacade {
     return [accessTokenCookie, refreshTokenCookie];
   }
 
-//   async checkIsDuplicateNickname(nickname: string) {
-//     const res = await this.userService.getUser({
-//       hashedNickname: createHash('md5').update(nickname).digest('hex'),
-//     });
+  //   async checkIsDuplicateNickname(nickname: string) {
+  //     const res = await this.userService.getUser({
+  //       hashedNickname: createHash('md5').update(nickname).digest('hex'),
+  //     });
 
-//     return !!res;
-//   }
-  
+  //     return !!res;
+  //   }
+
   async checkIsDuplicateNickname(nickname: string) {
     const res = await this.userService.getUser({
       nickname,
@@ -121,5 +120,4 @@ export default class UserFacade {
 
     return !!res;
   }
-
 }


### PR DESCRIPTION
### 설명
아래와 같이 엔티티 규약을 프론트엔드와 통일하도록 수정하였다.
- 닉네임: 15자 이하
- 피드 설명: 100자 이하
- 포스팅 글: 2000자 이하(db의 letter column varchar(225) -> text 로 변경)