### PR TITLE
refactor: 포스팅 무한 스크롤 api 수정

### DIFF
--- a/backend/src/common/guard/duedate.guard.ts
+++ b/backend/src/common/guard/duedate.guard.ts
@@ -17,6 +17,7 @@ export class DueDateGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext) {
     const req = context.switchToHttp().getRequest();
+    console.log(req.route.path);
     const { feedId } = req.params;
     const isCreatePostingApi =
       req.route.path === '/api/posting/:feedId' && req.route.methods.post;

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -108,17 +108,4 @@ export class FeedController {
     const feedInfo = await this.feedService.getFeedInfo(encryptedId, userId);
     return ResponseDto.OK_WITH_DATA(feedInfo);
   }
-
-  @Get('scroll/:feedId')
-  async getFeedPostingThumbnail(
-    @Param('feedId') encryptedId: string,
-    @Query() { size: scrollSize, index: startPostingId }: FeedScrollDto,
-  ) {
-    const postingThumbnailList = await this.feedService.getPostingThumbnails(
-      encryptedId,
-      startPostingId,
-      scrollSize,
-    );
-    return ResponseDto.OK_WITH_DATA(postingThumbnailList);
-  }
 }

--- a/backend/src/feed/feed.repository.ts
+++ b/backend/src/feed/feed.repository.ts
@@ -11,21 +11,6 @@ export class FeedRepository extends Repository<Feed> {
     return feed;
   }
 
-  async getThumbnailList(
-    startPostingId: number,
-    scrollSize: number,
-    id: number,
-  ) {
-    const postingThumbnaillist = await this.createQueryBuilder('feed')
-      .innerJoin('feed.postings', 'posting')
-      .select(['posting.id as id', 'posting.thumbnail as thumbanil'])
-      .where('feed.id = :id', { id })
-      .andWhere('posting.id > :startPostingId', { startPostingId })
-      .limit(scrollSize)
-      .getRawMany();
-    return postingThumbnaillist;
-  }
-
   async updateFeed(id: number, createFeedDto: CreateFeedDto) {
     await this.update(id, createFeedDto);
   }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -73,31 +73,6 @@ export class FeedService {
     return feed[0];
   }
 
-  async getPostingThumbnails(
-    encryptedFeedID: string,
-    startPostingId: number,
-    scrollSize: number,
-  ) {
-    const id = Number(decrypt(encryptedFeedID));
-    const postingThumbnailList = await this.feedRepository.getThumbnailList(
-      startPostingId,
-      scrollSize,
-      id,
-    );
-
-    // 쿼리 2번 - 추후쿼리 최적화 때 속도 비교
-    // const postingThumbnailList2 = await this.dataSource
-    //   .getRepository(Feed)
-    //   .find({
-    //     select: { postings: { id: true, thumbnail: true } },
-    //     relations: ['postings'],
-    //     where: { id, postings: { id: MoreThan(startPostingId) } },
-    //     take: postingCount,
-    //   });
-
-    return postingThumbnailList;
-  }
-
   async createFeed(createFeedDto: CreateFeedDto, userId: number) {
     let feed: Feed;
     await this.dataSource.transaction(async (manager) => {

--- a/backend/src/posting/dto/posting.scroll.dto.ts
+++ b/backend/src/posting/dto/posting.scroll.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumberString, IsOptional } from 'class-validator';
+
+export default class PostingScrollDto {
+  @IsNotEmpty()
+  @IsNumberString()
+  size: number;
+
+  @IsOptional()
+  @IsNumberString()
+  index?: number;
+}

--- a/backend/src/posting/posting.controller.ts
+++ b/backend/src/posting/posting.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Param, UseGuards, Get, Post, Body } from '@nestjs/common';
+import {
+  Controller,
+  Param,
+  UseGuards,
+  Get,
+  Post,
+  Body,
+  Query,
+} from '@nestjs/common';
 import { DueDateGuard } from '@root/common/guard/duedate.guard';
 import { PostingService } from '@posting/posting.service';
 import { AccessAuthGuard } from '@root/common/guard/accesstoken.guard';
@@ -7,13 +15,13 @@ import User from '@root/entities/User.entity';
 import { NonExistPostingError } from '@root/custom/customError/serverError';
 import ResponseDto from '@root/common/response/response.dto';
 import { CreatePostingReqDto } from './dto/create.posting.dto';
+import PostingScrollDto from './dto/posting.scroll.dto';
 
-@UseGuards(AccessAuthGuard)
 @Controller('posting')
 export class PostingController {
   constructor(private readonly postingService: PostingService) {}
 
-  @UseGuards(DueDateGuard)
+  @UseGuards(DueDateGuard, AccessAuthGuard)
   @Post('/:feedId')
   async createPosting(
     @UserReq() user: User,
@@ -32,8 +40,20 @@ export class PostingController {
     return ResponseDto.CREATED_WITH_DATA(postingId);
   }
 
+  @Get('scroll/:feedId')
+  async getFeedPostingThumbnail(
+    @Param('feedId') encryptedFeedId: string,
+    @Query() postingScrollDto: PostingScrollDto,
+  ) {
+    const postingThumbnailList = await this.postingService.getPostingThumbnails(
+      encryptedFeedId,
+      postingScrollDto,
+    );
+    return ResponseDto.OK_WITH_DATA(postingThumbnailList);
+  }
+
   @Get('/:feedId/:postingId')
-  @UseGuards(DueDateGuard)
+  @UseGuards(DueDateGuard, AccessAuthGuard)
   async getPosting(
     @Param('postingId') postingId: number,
     @Param('feedId') feedId: string,

--- a/backend/src/posting/posting.repository.ts
+++ b/backend/src/posting/posting.repository.ts
@@ -1,6 +1,7 @@
 import { CustomRepository } from '@root/common/typeorm/typeorm.decorator';
 import Posting from '@root/entities/Posting.entity';
-import { Repository } from 'typeorm';
+import { LessThan, Repository } from 'typeorm';
+import PostingScrollDto from './dto/posting.scroll.dto';
 
 @CustomRepository(Posting)
 export class PostingRepository extends Repository<Posting> {
@@ -15,5 +16,24 @@ export class PostingRepository extends Repository<Posting> {
       },
     });
     return posting;
+  }
+
+  async getThumbnailList(postingScrollDto: PostingScrollDto, feedId: number) {
+    const { index: startPostingId, size: scrollSize } = postingScrollDto;
+    console.log(startPostingId, scrollSize);
+
+    const whereOption = startPostingId
+      ? { feedId, id: LessThan(startPostingId) }
+      : { feedId };
+
+    const postingThumbnaillist = this.find({
+      where: whereOption,
+      select: { id: true, thumbnail: true },
+      order: {
+        id: 'DESC',
+      },
+      take: scrollSize,
+    });
+    return postingThumbnaillist;
   }
 }

--- a/backend/src/posting/posting.service.ts
+++ b/backend/src/posting/posting.service.ts
@@ -7,6 +7,7 @@ import Image from '@root/entities/Image.entity';
 import { CreatePostingDto } from './dto/create.posting.dto';
 import LookingPostingDto from './dto/looking.posting.dto';
 import { PostingRepository } from './posting.repository';
+import PostingScrollDto from './dto/posting.scroll.dto';
 
 @Injectable()
 export class PostingService {
@@ -43,5 +44,17 @@ export class PostingService {
       }
     });
     return posting.id;
+  }
+
+  async getPostingThumbnails(
+    encryptedFeedId: string,
+    postingScrollDto: PostingScrollDto,
+  ) {
+    const feedId = Number(decrypt(encryptedFeedId));
+    const postingThumbnailList = await this.postingRepository.getThumbnailList(
+      postingScrollDto,
+      feedId,
+    );
+    return postingThumbnailList;
   }
 }


### PR DESCRIPTION
### 설명
- 기존에 시간 순차적으로 포스팅을 가져왔는데, 시간 역순으로 가져오게 함으로써 사용자 편의성을 높였다.
- 기존에는 해당 api를 feed repository에서 처리했고,
  따라서 feed와 posting을 join 한 후, 해당하는 피드의 포스팅을 들고 오는 방식이었다면,
   이제는 바로 posting repository에서 join 없이 가져오도록 하였다.(posting table의 `feedId` FK 참조)