### PR TITLE
그룹피드 수정시 그룹 원 리스트 조회 api

### DIFF
--- a/backend/src/custom/customError/serverError.ts
+++ b/backend/src/custom/customError/serverError.ts
@@ -39,7 +39,11 @@ export class GroupFeedMembersCountError extends CustomError {
     );
   }
 }
-
+export class NonExistMemberError extends CustomError {
+  constructor() {
+    super('존재하지 않는 멤버입니다.', HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+}
 export class DuplicateNicknameError extends CustomError {
   constructor() {
     super('중복된 닉네임 입니다.', HttpStatus.CONFLICT);

--- a/backend/src/feed/dto/members.feed.dto.ts
+++ b/backend/src/feed/dto/members.feed.dto.ts
@@ -1,0 +1,19 @@
+import { PickType } from '@nestjs/swagger';
+import { NonExistMemberError } from '@root/custom/customError/serverError';
+import User from '@root/entities/User.entity';
+
+export default class FeedMembersDto extends PickType(User, [
+  'id',
+  'nickname',
+] as const) {
+  constructor(user: User) {
+    super();
+    this.id = user.id;
+    this.nickname = user.nickname;
+  }
+
+  static createFeedMemberDto(user: User) {
+    if (!user) throw new NonExistMemberError();
+    return new FeedMembersDto(user);
+  }
+}

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -19,7 +19,7 @@ import { AuthorizationGuard } from '@root/common/guard/authorization.guard';
 import CreateFeedDto from '@feed/dto/create.feed.dto';
 import CustomValidationPipe from '@root/common/pipes/customValidationPipe';
 import { FeedService } from '@feed/feed.service';
-import { decrypt } from '@feed/feed.utils';
+import { decrypt, encrypt } from '@feed/feed.utils';
 import ResponseDto from '@root/common/response/response.dto';
 import FeedScrollDto from './dto/request/feed.scroll.dto';
 
@@ -107,5 +107,19 @@ export class FeedController {
     const userId = user.id;
     const feedInfo = await this.feedService.getFeedInfo(encryptedId, userId);
     return ResponseDto.OK_WITH_DATA(feedInfo);
+  }
+
+  @UseGuards(AuthorizationGuard)
+  @Get('members/:feedId')
+  async getFeedMemberList(
+    @Param('feedId') encryptedId: string,
+    @UserReq() user: User,
+  ) {
+    const userId = user.id;
+    const feedMemberList = await this.feedService.getFeedMemberList(
+      encryptedId,
+      userId,
+    );
+    return ResponseDto.OK_WITH_DATA(feedMemberList);
   }
 }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -1,16 +1,12 @@
 /* eslint-disable prettier/prettier */
 import { Injectable } from '@nestjs/common';
-import {
-  CustomRepositoryCannotInheritRepositoryError,
-  DataSource,
-} from 'typeorm';
+import { DataSource } from 'typeorm';
 import { Feed } from '@root/entities/Feed.entity';
 import UserFeedMapping from '@root/entities/UserFeedMapping.entity';
 import {
   GroupFeedMembersCountError,
   NonExistFeedError,
 } from '@root/custom/customError/serverError';
-import { UserRepository } from '@root/users/users.repository';
 import User from '@root/entities/User.entity';
 import CreateFeedDto from '@feed/dto/create.feed.dto';
 import { decrypt } from '@feed/feed.utils';
@@ -20,12 +16,12 @@ import FeedInfoDto from '@feed/dto/info.feed.dto';
 import { FeedRepository } from '@feed/feed.repository';
 import FeedResponseDto from './dto/response/feed.response.dto';
 import { UserFeedMappingRepository } from './user.feed.mapping.repository';
+import FeedMembersDto from './dto/members.feed.dto';
 
 @Injectable()
 export class FeedService {
   constructor(
     private feedRepository: FeedRepository,
-    private userRepository: UserRepository,
     private userFeedMappingRepository: UserFeedMappingRepository,
     private dataSource: DataSource,
   ) {}
@@ -64,6 +60,18 @@ export class FeedService {
       }
     });
     return feedInfoDto;
+  }
+
+  async getFeedMemberList(encryptedFeedID: string, userId: number) {
+    const feedId = Number(decrypt(encryptedFeedID));
+    const memberList = await this.userFeedMappingRepository.getFeedMemberList(
+      userId,
+      feedId,
+    );
+    const feedMemberDtoList: FeedMembersDto[] = memberList.map((member) => {
+      return FeedMembersDto.createFeedMemberDto(member);
+    });
+    return feedMemberDtoList;
   }
 
   async getFeedById(encryptedFeedID: string) {

--- a/backend/src/feed/user.feed.mapping.repository.ts
+++ b/backend/src/feed/user.feed.mapping.repository.ts
@@ -25,4 +25,14 @@ export class UserFeedMappingRepository extends Repository<UserFeedMapping> {
       .getOne();
     return owner;
   }
+
+  async getFeedMemberList(userId: number, feedId: number) {
+    const feedMemberList = await this.createQueryBuilder('user_feed_mapping')
+      .innerJoin('user_feed_mapping.user', 'users')
+      .select(['users.id as id', 'users.nickname as nickname'])
+      .where('user_feed_mapping.feedId  = :feedId', { feedId })
+      .andWhere('user_feed_mapping.userId != :userId', { userId })
+      .getRawMany();
+    return feedMemberList;
+  }
 }


### PR DESCRIPTION
## 설명 
그룹피드의 수정 권한은 그룹 피드의 주인에게만 주어져야하기 때문에, AuthorizationGuard를 걸어주었습니다. 

user-feed-mapping 테이블과 user 테이블을 조인해서 해당하는 그룹 피드 아이디를 기준으로 select를 하도록 구현했습니다. 
이때, 그룹원을 조회할 시에는 본인의 닉네임을 제외하고 나머지 그룹원들의 닉네임과 아이디 값을 조회해야하므로, where 조건을 하나 더 추가해, user-feed-mapping 테이블의 userId 값이 본인의 id 값인 것을 제외하고 추출할 수 있도록 구현했습니다. 