### PR TITLE
[FE] 피드 수정 기능 구현

### DIFF
--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -147,7 +147,7 @@ export class FeedService {
         select: { userId: true },
       });
       const prevMemberIdList = prevMemberList.map((member) => member.userId);
-      for await (const userId of memberIdList) {
+      for await (const userId of prevMemberIdList) {
         if (!memberIdList.includes(userId)) {
           await manager.delete(UserFeedMapping, { userId });
         }

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import './style.scss'
 import { ReactComponent as WarningIcon } from '@assets/warningIcon.svg'
 import { debounce } from 'lodash'
@@ -10,22 +10,37 @@ interface IInput {
   bind: React.RefObject<HTMLInputElement>
   validate?: (str: string) => string
   onChangeCb?: (str: string) => void
+  defaultValue?: string
 }
 const Input = ({
   label = '',
   placeholder = '',
   type = 'text',
   bind,
+  defaultValue = '',
   validate = (str: string) => '',
   onChangeCb = (str: string) => {}
 }: IInput) => {
   const [warningText, setWarningText] = useState('')
+  const [inputText, setInputText] = useState('')
   const debouncedWarningText = debounce(setWarningText, 500)
 
+  useEffect(() => {
+    if (defaultValue !== '') {
+      setInputText(defaultValue)
+    }
+  }, [defaultValue])
+
+  useEffect(() => {
+    if (inputText !== '') {
+      const text = validate(inputText)
+      debouncedWarningText(text)
+      onChangeCb(inputText)
+    }
+  }, [inputText])
+
   const handleEvent = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const text = validate(e.target.value)
-    debouncedWarningText(text)
-    onChangeCb(e.target.value)
+    setInputText(e.target.value)
   }
 
   return (
@@ -37,7 +52,7 @@ const Input = ({
           <span>{warningText}</span>
         </div>
       )}
-      <input type={type} placeholder={placeholder} onChange={handleEvent} ref={bind} />
+      <input type={type} placeholder={placeholder} onChange={handleEvent} ref={bind} value={inputText} />
     </div>
   )
 }

--- a/frontend/src/hooks/usePatch.tsx
+++ b/frontend/src/hooks/usePatch.tsx
@@ -1,0 +1,23 @@
+import { useCallback } from 'react'
+import axios from 'axios'
+
+const usePatch = (url: string) => {
+  const patch = useCallback(
+    async (body: object, options?: object) => {
+      try {
+        const response = await axios.patch(`/api${url}`, body, { ...options, withCredentials: true })
+        console.log(response.data)
+        return response.data
+      } catch (err: any) {
+        console.log(err)
+
+        return err.response.data
+      }
+    },
+    [url]
+  )
+
+  return patch
+}
+
+export default usePatch

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { Routes, Route, BrowserRouter, Navigate } from 'react-router-dom'
 import Feed from '@pages/Feed'
 import CreateFeed from '@pages/CreateFeed'
+import EditFeed from '@pages/EditFeed'
 import Write from '@pages/Write'
 import SignIn from '@pages/SignIn'
 import Posting from '@pages/Posting'
@@ -30,6 +31,7 @@ root.render(
         <Route path="/SignIn/Info" element={<SigninRoute Component={Info} />} />
         <Route path="/SignIn" element={<SigninRoute Component={SignIn} />} />
         <Route path="/Createfeed/:path" element={<AuthRoute Component={CreateFeed} />} />
+        <Route path="/EditFeed/:path/:feedId" element={<AuthRoute Component={EditFeed} />} />
         <Route path="/Feeds" element={<AuthRoute Component={Feeds} />} />
         <Route path="/Posting" element={<Posting />} />
         <Route path="/*" element={<Error />} />

--- a/frontend/src/pages/EditFeed/EditFeedButton/index.tsx
+++ b/frontend/src/pages/EditFeed/EditFeedButton/index.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import { isEmpty } from 'lodash'
+import { IEditFeedButton } from '../types'
+import usePatch from '@hooks/usePatch'
+import { IResponse } from '@src/types'
+
+const EditFeedButton = ({ getFeedInfos }: IEditFeedButton) => {
+  const { path, feedId } = useParams<{ path: string, feedId: string }>()
+  const patchPersonalFeed = usePatch(`/feed/${feedId as string}`)
+  const patchGroupFeed = usePatch(`/feed/group/${feedId as string}`)
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false)
+  const navigate = useNavigate()
+
+  const onFeedBtnClicked = async () => {
+    setIsButtonDisabled(true)
+    const formData = await getFeedInfos()
+    if (isEmpty(formData)) {
+      setIsButtonDisabled(false)
+      return
+    }
+    if (path === 'personal') {
+      const { success }: IResponse = await patchPersonalFeed(formData)
+      if (success) navigate(`/Feed/${feedId as string}`)
+      else {
+        toast('오류가 발생했습니다. 다시 클릭해주세요.')
+        setIsButtonDisabled(false)
+      }
+    }
+    if (path === 'group') {
+      const { success }: IResponse = await patchGroupFeed(formData)
+      if (success) navigate(`/Feed/${feedId as string}`)
+      else {
+        toast('오류가 발생했습니다. 다시 클릭해주세요.')
+        setIsButtonDisabled(false)
+      }
+    }
+  }
+
+  return (
+    <button className="button-large" onClick={onFeedBtnClicked} disabled={isButtonDisabled}>
+      피드 수정하기
+    </button>
+  )
+}
+
+export default EditFeedButton

--- a/frontend/src/pages/EditFeed/GroupMember/Suggestions.tsx
+++ b/frontend/src/pages/EditFeed/GroupMember/Suggestions.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import useSWR from 'swr'
+import fetcher from '@src/util/fetcher'
+import { isEmpty } from 'lodash'
+import { ISuggestion } from '../types'
+
+interface ISuggestions {
+  nickname: string
+  members: ISuggestion[]
+  setMembers: (s: ISuggestion) => void
+}
+
+const Suggestions = ({ nickname, members, setMembers }: ISuggestions) => {
+  const { data, mutate } = useSWR<ISuggestion[]>(`/users/search/${nickname}`, fetcher)
+
+  if (isEmpty(data)) {
+    return null
+  }
+
+  const isMemberAlready = (newMember: ISuggestion) => {
+    return members.filter(member => member.id === newMember.id).length > 0
+  }
+
+  const memberSearchResult = data?.map((suggestion) => (
+    <button
+      className="suggestion-wrapper"
+      key={suggestion.id}
+      onClick={(e) => {
+        e.preventDefault()
+        setMembers(suggestion)
+        void mutate([], false)
+      }}
+      disabled={isMemberAlready(suggestion)}
+    >
+      <span className="suggestion-nickname">{suggestion.nickname}</span>
+      <span className="suggestion-add">추가</span>
+    </button>
+  ))
+
+  return (
+    <>
+      {data != null && (
+        <div className="suggestions-wrapper">
+          {memberSearchResult}
+        </div>
+      )}
+    </>
+  )
+}
+
+export default Suggestions

--- a/frontend/src/pages/EditFeed/GroupMember/index.tsx
+++ b/frontend/src/pages/EditFeed/GroupMember/index.tsx
@@ -1,0 +1,71 @@
+
+import React, { useRef, useState, useEffect } from 'react'
+import useSWR from 'swr'
+import { useParams } from 'react-router-dom'
+import { debounce, isEmpty } from 'lodash'
+import Suggestions from './Suggestions'
+import { IGroupMember, ISuggestion } from '../types'
+import { ReactComponent as XIcon } from '@assets/XIcon.svg'
+import Input from '@src/components/Input'
+import fetcher from '@util/fetcher'
+
+const GroupMember = ({ members, setMembers }: IGroupMember) => {
+  const nicknameRef = useRef<HTMLInputElement>(null)
+  const [nickname, setNickname] = useState('')
+  const { feedId } = useParams<{ feedId: string }>()
+  const { data: feedMembers } = useSWR(feedId !== undefined ? `/feed/members/${feedId as string}` : null, fetcher)
+
+  useEffect(() => {
+    if (feedMembers) {
+      setMembers(feedMembers)
+    }
+  }, [feedMembers])
+
+  const debouncedSearch = debounce((value: string) => {
+    setNickname(value)
+  }, 500)
+
+  const handleSuggestionClick = (newMember: ISuggestion) => {
+    if (members.every(({ id }) => id !== newMember.id)) {
+      setMembers([...members, newMember])
+    }
+    if (!isEmpty(nicknameRef.current)) {
+      nicknameRef.current.value = ''
+      setNickname(nicknameRef.current.value)
+    }
+  }
+
+  const feedMembersResult = members.map(({ nickname, id }) => (
+    <button
+      key={id}
+      className="form-member"
+      onClick={(e) => {
+        e.preventDefault()
+        setMembers(members.filter((member) => member.id !== id))
+      }}>
+      <span>{nickname}</span>
+        <XIcon fill="#ea4b35" />
+    </button>
+  ))
+
+  return (
+    <div>
+      <Input
+        label="그룹원 추가"
+        bind={nicknameRef}
+        placeholder="그룹원의 닉네임을 입력해주세요"
+        onChangeCb={debouncedSearch}
+      />
+      {!isEmpty(nickname) && <Suggestions nickname={nickname} members={members} setMembers={handleSuggestionClick} />}
+      <div className="add-group-people">
+        <label className="form-label" htmlFor="">그룹원 목록</label>
+        {isEmpty(members)
+          ? (<span className="form-no-member">현재 추가된 그룹원이 없습니다</span>)
+          : (<div className="form-members-wrapper">{feedMembersResult}</div>)
+        }
+      </div>
+    </div>
+  )
+}
+
+export default GroupMember

--- a/frontend/src/pages/EditFeed/index.tsx
+++ b/frontend/src/pages/EditFeed/index.tsx
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { useEffect, useRef, useState } from 'react'
+import useSWR from 'swr'
+import { isEmpty } from 'lodash'
+import { useParams } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import './style.scss'
+import GroupMember from './GroupMember'
+import EditFeedButton from './EditFeedButton'
+import { IFeedForm, ISuggestion } from './types'
+import Error from '../Error'
+import defaultUserImage from '@assets/defaultUserImage.svg'
+import Header from '@components/Header'
+import Input from '@components/Input'
+import Toast from '@components/Toast'
+import usePost from '@hooks/usePost'
+import { compressImage } from '@util/imageCompress'
+import { cropImg } from '@util/cropImg'
+import { canvasToFile } from '@util/canvasToFile'
+import fetcher from '@util/fetcher'
+import { getFeedThumbUrl } from '@util/imageQuery'
+import { uploadImage } from '@util/uploadImage'
+import {
+  getWarningDescription,
+  getWarningName,
+  getWarningMembers,
+  validDescription,
+  validMembers,
+  validName
+} from '@util/validation'
+
+interface IFeedInfo {
+  name: string
+  thumbnail: string
+  description: string
+  dueDate: string
+  isOwner: boolean
+  isGroupFeed: boolean
+  postingCnt: number
+}
+
+const EditFeed = () => {
+  const nameRef = useRef<HTMLInputElement>(null)
+  const [thumbnail, setThumbnail] = useState<File>()
+  const descriptionRef = useRef<HTMLInputElement>(null)
+  const [members, setMembers] = useState<ISuggestion[]>([])
+  const [isExistThumb, setIsExistThumb] = useState<Boolean>(false)
+  const thumbnailInput = useRef<HTMLInputElement>(null)
+  const [thumbnailSrc, setThumbnailSrc] = useState('')
+  const postImage = usePost('/image')
+  const { path, feedId } = useParams<{ path: string, feedId: string }>()
+  const { data: feedInfo, error: feedError } = useSWR<IFeedInfo>(
+    feedId !== undefined ? `/feed/info/${feedId}` : null,
+    fetcher
+  )
+
+  useEffect(() => {
+    if (feedInfo !== undefined) {
+      setThumbnailSrc(getFeedThumbUrl(feedInfo?.thumbnail as string))
+      setIsExistThumb(true)
+    }
+  }, [feedInfo])
+
+  const onChangeFeedThumbnail = async (e?: any, defaultImage?: string) => {
+    setThumbnailSrc(URL.createObjectURL(e.target.files[0]))
+    setThumbnail(undefined)
+    const croppedCanvas = await cropImg(e.target.files[0])
+    const croppedFile = await canvasToFile(croppedCanvas)
+    const compressedImage = await compressImage(croppedFile)
+    setThumbnail(compressedImage)
+    setIsExistThumb(false)
+  }
+
+  const onThumbnailUploadClicked = (e: any) => {
+    if (!isEmpty(thumbnailInput.current)) thumbnailInput.current.click()
+  }
+
+  const getFeedInfos = async (): Promise<IFeedForm | undefined> => {
+    if (isEmpty(nameRef.current) || isEmpty(descriptionRef.current)) {
+      toast('페이지에 오류가 있습니다. 새로고침 후 다시 작성해주세요.')
+      return undefined
+    }
+    if (!validName(nameRef.current.value)) {
+      toast(getWarningName(nameRef.current.value))
+      return undefined
+    }
+    if (!validDescription(descriptionRef.current.value)) {
+      toast(getWarningDescription(descriptionRef.current.value))
+      return undefined
+    }
+    if (path === 'group' && !validMembers(members!)) {
+      toast(getWarningMembers(members!))
+      return undefined
+    }
+    if (!isExistThumb && thumbnail === undefined) {
+      toast('썸네일 압축 중 입니다.')
+      return undefined
+    }
+    const formData: IFeedForm = {
+      name: nameRef.current.value,
+      description: descriptionRef.current.value,
+      dueDate: feedInfo?.dueDate,
+      thumbnail: isExistThumb ? feedInfo?.thumbnail : await getThumbnailUrl()
+    }
+    const memberIdList = getMembers()
+    if (!isEmpty(members)) formData.memberIdList = memberIdList
+    return formData
+  }
+
+  const getThumbnailUrl = async () => {
+    const [thumbnailUrl] = await uploadImage([thumbnail!], postImage)
+    return thumbnailUrl as string
+  }
+
+  const getMembers = () => {
+    if (path !== 'group') return undefined
+    return members.map(({ id }) => Number(id))
+  }
+
+  if (!(path === 'group' || path === 'personal')) return <Error />
+
+  return (
+    <div className="createfeed-page">
+      <Header page="CreateFeed" text={'피드 수정'} />
+      <div className="createfeed-body">
+        <div className="profile-pic-wrapper">
+          <button onClick={onThumbnailUploadClicked}>
+            <div className="profile-pic-circle">
+              <img
+                src={thumbnailSrc}
+                alt="프로필 썸네일 미리보기"
+                onLoad={() => {
+                  URL.revokeObjectURL(thumbnailSrc)
+                }}
+                onError={(e) => {
+                  setThumbnailSrc(defaultUserImage)
+                }}
+              />
+            </div>
+            <span>피드 사진 생성</span>
+          </button>
+          <input type="file" accept="image/jpeg, image/png" ref={thumbnailInput} onChange={onChangeFeedThumbnail}/>
+        </div>
+        <Input label="제목" placeholder="피드의 제목을 입력해주세요" bind={nameRef} validate={getWarningName} defaultValue={feedInfo?.name as string}/>
+        <Input
+          label="소개"
+          placeholder="피드의 소개를 입력해주세요"
+          bind={descriptionRef}
+          validate={getWarningDescription}
+          defaultValue={feedInfo?.description as string}
+        />
+        {path === 'group' && <GroupMember members={members} setMembers={setMembers} />}
+        <EditFeedButton getFeedInfos={getFeedInfos} />
+        <Toast />
+      </div>
+    </div>
+  )
+}
+
+export default EditFeed

--- a/frontend/src/pages/EditFeed/style.scss
+++ b/frontend/src/pages/EditFeed/style.scss
@@ -1,0 +1,141 @@
+@import '@src/global';
+.createfeed-page {
+  @include page;
+}
+.createfeed-header {
+  @include header;
+}
+.createfeed-body {
+  @include body;
+  @include display-col(1.25vw);
+  @include not-mobile {
+    @include display-col(5px);
+  }
+
+  .profile-pic-wrapper {
+    @include vcenter;
+    @include display-col(3.75vw);
+    @include not-mobile {
+      @include display-col(16px);
+    }
+    .profile-pic-circle {
+      @include circle(22.5vw, true, $grey);
+      @include not-mobile {
+        @include circle(95px, true, $grey);
+      }
+    }
+    span {
+      @include bold(3.75vw, $primary-3);
+      display: block;
+      padding: 1.88vw 0 1.88vw 0;
+      @include not-mobile {
+        @include bold(16px, $primary-3);
+        padding: 8px 0 8px 0;
+      }
+    }
+    input {
+      display: none;
+    }
+  }
+  .button-large {
+    @include button-large;
+    margin: 8.75vw 0;
+    @include not-mobile {
+      margin: 37px 0;
+    }
+  }
+  .add-group-people {
+    .form-label {
+      margin-top: 1.25vw;
+      @include medium(4.375vw, $black);
+      display: block;
+      @include not-mobile {
+        margin-top: 5px;
+        @include medium(18px, $black);
+      }
+    }
+    .form-no-member {
+      @include regular(3.75vw, $grey);
+      margin: 2.5vw 0;
+      @include not-mobile {
+        @include regular(16px, $grey);
+        margin: 10px 0;
+      }
+    }
+    .form-members-wrapper {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.25vw;
+      margin: 2.5vw 0;
+      @include not-mobile {
+        gap: 5px;
+        margin: 10px 0;
+      }
+      .form-member {
+        @include vhcenter;
+        @include regular(3.75vw, $primary-3);
+        vertical-align: middle;
+        padding: 1.25vw 1.875vw;
+        border-radius: 4px;
+        background-color: $primary-1;
+        display: inline;
+        flex-direction: row;
+        @include not-mobile {
+          @include regular(16px, $primary-3);
+          padding: 5px 8px;
+        }
+        svg {
+          width: 3vw;
+          height: 3vw;
+          margin-left: 1.25vw;
+          padding-bottom: 0.4vw;
+          @include not-mobile {
+            width: 12px;
+            height: 12px;
+            margin-left: 5px;
+            padding-bottom: 2px;
+          }
+        }
+      }
+    }
+  }
+}
+.suggestions-wrapper {
+  border: 1px solid $grey;
+  border-radius: 8px;
+  margin-bottom: 1.25vw;
+  .suggestion {
+    &-wrapper {
+      padding: 2.5vw 5vw;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      width: calc(100% - 10vw);
+      @include not-mobile {
+        padding: 10px 20px;
+        width: calc(100% - 40px);
+      }
+      .suggestion-nickname {
+        @include regular(3.75vw, $black);
+        @include not-mobile {
+          @include regular(16px, $black);
+        }
+      }
+      .suggestion-add {
+        @include medium(3.75vw, $black);
+        @include not-mobile {
+          @include medium(16px, $black);
+        }
+      }
+      &:disabled {
+        .suggestion-add {
+          @include medium(3.75vw, $grey-font);
+          @include not-mobile {
+            @include medium(16px, $grey-font);
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/frontend/src/pages/EditFeed/types.ts
+++ b/frontend/src/pages/EditFeed/types.ts
@@ -1,0 +1,18 @@
+export interface IFeedForm {
+  name?: string
+  thumbnail?: string
+  description?: string
+  dueDate?: string
+  memberIdList?: number[]
+}
+export interface ISuggestion {
+  id: string
+  nickname: string
+}
+export interface IGroupMember {
+  members: ISuggestion[]
+  setMembers: React.Dispatch<React.SetStateAction<ISuggestion[]>>
+}
+export interface IEditFeedButton {
+  getFeedInfos: () => Promise<IFeedForm | undefined>
+}

--- a/frontend/src/pages/Feed/FeedProfile/index.tsx
+++ b/frontend/src/pages/Feed/FeedProfile/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import React, { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import useSWR from 'swr'
 import './style.scss'
 import { ReactComponent as ShareIcon } from '@assets/shareIcon.svg'
+import { ReactComponent as EditIcon } from '@assets/editIcon.svg'
 import DefaultUserImage from '@assets/defaultUserImage.svg'
 import { getFeedThumbUrl } from '@util/imageQuery'
 import { remainDueDate } from '@util/index'
@@ -38,6 +39,10 @@ const FeedProfile = ({ name, thumbnail, description, dueDate, postingCnt, isOwne
       }
     })
   }
+  const editButton =
+  <Link className="edit-button" to={`/EditFeed/${isGroupFeed ? 'group' : 'personal'}/${feedId}`}>
+    <EditIcon/>
+  </Link>
   return (
     <div>
       <div className="feed-profile-header-wrapper">
@@ -46,6 +51,7 @@ const FeedProfile = ({ name, thumbnail, description, dueDate, postingCnt, isOwne
             <div className="feed-profile-image">
               <img src={thumbnail !== '' ? getFeedThumbUrl(thumbnail) : DefaultUserImage} alt="유저 프로필 이미지" />
             </div>
+            {isOwner && editButton}
           </div>
           <div className="feed-profile-info-wrapper">
             <span className="feed-profile-name">{name}</span>


### PR DESCRIPTION
# 개요
  
  피드 수정 페이지를 구현하였습니다.

<table>
   <thead>
      <tr>
         <th width="500px">피드 사진, 소개 수정 및 그룹원 추가</th>
         <th width="500px">그룹원 삭제</th>
      </tr>
   </thead>
   <tbody>
      <tr width="600px">
         <td>
            <img src="https://user-images.githubusercontent.com/58061756/209579130-2ec20259-ed7c-41b4-97ef-c60a39b7fe32.gif">
         </td>
         <td>
            <img src="https://user-images.githubusercontent.com/58061756/209579136-50a459ed-4632-4e0c-8780-c9e75a9d4f6c.gif">
       </td>
      </tr>
   </tbody>
</table>

  - URL은 다음과 같습니다.
    - `~/EditFeed/:path/:feedId`
    - `path` = `personal` or `group`
    - `feedId` = `feed`의 해쉬 ID
  - 피드의 기존 정보 (프로필, 제목, 소개, 그룹원) 을 불러옵니다.
  - 피드의 공개일은 나타나지 않습니다.
  - 만약 이미 추가된 그룹원이라면, 추가 버튼이 `disabled` 된 형태로 나타납니다. 

    <table>
       <thead>
          <tr>
             <th width="500px">이미 추가된 그룹원</th>
             <th width="500px">추가되지 않은 그룹원</th>
          </tr>
       </thead>
       <tbody>
          <tr width="600px">
             <td>
                <img src="https://user-images.githubusercontent.com/58061756/209579468-78beca41-d183-4656-90ca-1148342fdc56.png">
             </td>
             <td>
                <img src="https://user-images.githubusercontent.com/58061756/209579485-240de58f-7c59-4a87-bf38-60c89ced91a9.png">
           </td>
          </tr>
       </tbody>
    </table>

# 주요 변경 사항

### 피드 수정 API 수정
그룹 피드 수정에서 그룹원 삭제가 안되는 이슈를 발견하였습니다.
따라서 아래와 같이 변경하였습니다.
```typescript
      for await (const userId of memberIdList) {
      for await (const userId of prevMemberIdList) {
```
### 인풋 컴포넌트 수정
input 컴포넌트에 default value를 넣어줘야 하는 상황이 발생함에 따라, 
구현의 편의성을 위해, input value를 useState로 관리하도록 변경하였습니다.
