### PR TITLE
refactor: 서비스 레이어에서 transacion 실행하도록 수정

### DIFF
--- a/backend/src/image/dto/create.image.dto.ts
+++ b/backend/src/image/dto/create.image.dto.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import Image from '@root/entities/Image.entity';
+
+export default class CreateImage extends PickType(Image, [
+  'posting',
+  'url',
+] as const) {}

--- a/backend/src/image/image.repository.ts
+++ b/backend/src/image/image.repository.ts
@@ -1,0 +1,17 @@
+import { CustomRepository } from '@root/common/typeorm/typeorm.decorator';
+import Image from '@root/entities/Image.entity';
+import { Repository } from 'typeorm';
+import CreateImage from './dto/create.image.dto';
+
+@CustomRepository(Image)
+export class ImageRepository extends Repository<Image> {
+  async saveImage(createImageList: CreateImage[]) {
+    await this.manager
+      .createQueryBuilder()
+      .insert()
+      .into(Image)
+      .values(createImageList)
+      .updateEntity(false)
+      .execute();
+  }
+}

--- a/backend/src/posting/dto/create.posting.dto.ts
+++ b/backend/src/posting/dto/create.posting.dto.ts
@@ -38,7 +38,7 @@ export class CreatePostingDecoratorDto {
   createPostingDto: {
     letter: string;
     thumbnail: string;
-    sendeId: number;
+    senderId: number;
     feedId: number;
   };
 

--- a/backend/src/posting/posting.module.ts
+++ b/backend/src/posting/posting.module.ts
@@ -8,12 +8,14 @@ import { JwtService } from '@nestjs/jwt';
 import { FeedModule } from '@root/feed/feed.module';
 import TypeOrmCustomModule from '@root/common/typeorm/typeorm.module';
 import { PostingRepository } from '@posting/posting.repository';
+import { ImageRepository } from '@root/image/image.repository';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Posting]),
     FeedModule,
     TypeOrmCustomModule.forCustomRepository([PostingRepository]),
+    TypeOrmCustomModule.forCustomRepository([ImageRepository]),
   ],
   controllers: [PostingController],
   providers: [PostingService, AuthenticationService, JwtService],

--- a/backend/src/posting/posting.repository.ts
+++ b/backend/src/posting/posting.repository.ts
@@ -1,9 +1,7 @@
 import { CustomRepository } from '@root/common/typeorm/typeorm.decorator';
-import Image from '@root/entities/Image.entity';
 import Posting from '@root/entities/Posting.entity';
-import { LicenseManagerUserSubscriptions } from 'aws-sdk';
-import { LessThan, Repository } from 'typeorm';
-import { CreatePostingDecoratorDto } from './dto/create.posting.dto';
+import { LessThan, Repository, DataSource } from 'typeorm';
+import { CreatePostingDto } from './dto/create.posting.dto';
 import PostingScrollDto from './dto/posting.scroll.dto';
 
 @CustomRepository(Posting)
@@ -21,27 +19,9 @@ export class PostingRepository extends Repository<Posting> {
     return posting;
   }
 
-  async savePosting({
-    createPostingDto,
-    imageList,
-  }: CreatePostingDecoratorDto) {
-    let posting: Posting;
-    await this.manager.transaction(async (manager) => {
-      posting = await manager.save(Posting, createPostingDto);
-
-      const insertImageList = imageList.map((imageUrl) => {
-        return { posting, url: imageUrl };
-      });
-
-      await manager
-        .createQueryBuilder()
-        .insert()
-        .into(Image)
-        .values(insertImageList)
-        .updateEntity(false)
-        .execute();
-    });
-    return posting.id;
+  async savePosting(createPostingDto: CreatePostingDto) {
+    const posting = await this.save(createPostingDto);
+    return posting;
   }
 
   async getThumbnailList(postingScrollDto: PostingScrollDto, feedId: number) {

--- a/backend/src/posting/posting.repository.ts
+++ b/backend/src/posting/posting.repository.ts
@@ -1,8 +1,8 @@
-import { InjectRepository } from '@nestjs/typeorm';
 import { CustomRepository } from '@root/common/typeorm/typeorm.decorator';
 import Image from '@root/entities/Image.entity';
 import Posting from '@root/entities/Posting.entity';
-import { DataSource, LessThan, Repository } from 'typeorm';
+import { LicenseManagerUserSubscriptions } from 'aws-sdk';
+import { LessThan, Repository } from 'typeorm';
 import { CreatePostingDecoratorDto } from './dto/create.posting.dto';
 import PostingScrollDto from './dto/posting.scroll.dto';
 

--- a/backend/src/posting/posting.service.ts
+++ b/backend/src/posting/posting.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { decrypt } from '@root/feed/feed.utils';
+import Posting from '@root/entities/Posting.entity';
+import { DataSource } from 'typeorm';
+import { ImageRepository } from '@root/image/image.repository';
 import { CreatePostingDecoratorDto } from './dto/create.posting.dto';
 import LookingPostingDto from './dto/looking.posting.dto';
 import { PostingRepository } from './posting.repository';
@@ -7,7 +10,11 @@ import PostingScrollDto from './dto/posting.scroll.dto';
 
 @Injectable()
 export class PostingService {
-  constructor(private postingRepository: PostingRepository) {}
+  constructor(
+    private postingRepository: PostingRepository,
+    private imageRepository: ImageRepository,
+    private dataSource: DataSource,
+  ) {}
 
   async getPosting(postingId: number, encryptedFeedId: string) {
     const feedId = Number(decrypt(encryptedFeedId));
@@ -15,11 +22,24 @@ export class PostingService {
     return LookingPostingDto.createLookingPostingDto(posting[0]);
   }
 
-  async createPosting(createPostingDecoratorDto: CreatePostingDecoratorDto) {
-    const postingId = await this.postingRepository.savePosting(
-      createPostingDecoratorDto,
-    );
-    return postingId;
+  async createPosting({
+    createPostingDto,
+    imageList,
+  }: CreatePostingDecoratorDto) {
+    let posting: Posting;
+    await this.dataSource.transaction(async (manager) => {
+      const postingRepository = manager.withRepository(this.postingRepository);
+      const imageRepository = manager.withRepository(this.imageRepository);
+
+      posting = await postingRepository.savePosting(createPostingDto);
+
+      const insertImageList = imageList.map((imageUrl) => {
+        return { posting, url: imageUrl };
+      });
+
+      await imageRepository.saveImage(insertImageList);
+    });
+    return posting.id;
   }
 
   async getPostingThumbnails(

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -7,12 +7,12 @@ import FindUserDto from './dto/find.user.dto';
 @CustomRepository(User)
 export class UserRepository extends Repository<User> {
   async joinUser(user: JoinRequestDto) {
-    const userId = await this.createQueryBuilder()
+    const insertedUser = await this.createQueryBuilder()
       .insert()
       .into(User)
       .values(user)
       .execute();
-    return userId.raw.insertId;
+    return insertedUser.raw.insertId;
   }
 
   async findUser(findUserInterface: FindUserDto) {


### PR DESCRIPTION
### 설명
기존에 포스팅 생성 api의 경우
- posting 테이블에 새로운 posting entity 삽입
- image 테이블에 posting의 등록 이미지 삽입

의 과정을 모두 posting repository의 `savePosting` 에서 트랜잭션 처리하였다.

그런데 
1. transaction 처리의 경우 service layer에서, 그리고 그 각각의 세부 db 작업을 repository 레이어에서
2. posting repository에서 image repostiory 작업도 하는 것은 동일 레이어가 서로를 참고하는 것으므로 어색하다

따라서 service layer에서 transaction을 처리하도록 수정하엿다.